### PR TITLE
Add training launch diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md - NAM-BOT Development Guide (v0.5.1-rc.1)
+# AGENTS.md - NAM-BOT Development Guide (v0.5.1-rc.2)
 
 This document provides guidance for AI agents working on the NAM-BOT project.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1-rc.2] - 2026-05-04
+
+### Added
+
+- Diagnostics now include Training Launch readiness checks that verify workspace writability and the same PTY-based `nam-full` launch path used by real training jobs
+
+### Changed
+
+- Diagnostics screen now uses compact readiness tiles, a prioritized action center, and a dense check matrix so setup guidance is easier to scan
+- Lightning package metadata checks are de-duplicated across simultaneous diagnostics runs to reduce repeated Conda probes
+
+### Fixed
+
+- Diagnostics no longer starts overlapping launch probes while earlier checks are still running, reducing status churn and repeated terminal commands
+
 ## [0.5.1-rc.1] - 2026-05-02
 
 ### Changed

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -9,13 +9,15 @@ It is designed to answer two practical questions before or during training:
 - can NAM-BOT actually reach the configured NAM backend
 - can that backend use the accelerator path you expect, especially CUDA on Windows or MPS on Apple Silicon
 - does the environment avoid known compromised Lightning releases before NAM-BOT imports NAM or Lightning
+- can NAM-BOT launch the same terminal process path used by real training jobs
 
-The screen is intentionally split into backend validation and accelerator diagnostics so users can tell the difference between "NAM is not set up correctly" and "NAM works, but GPU support is not healthy yet."
+The screen is intentionally split into compact readiness areas so users can tell the difference between "NAM is not set up correctly," "NAM works but GPU support is not healthy yet," and "basic checks pass but the actual training launch path is blocked."
 
 ## Goals
 
 - Give users a fast pass/fail check for the currently selected backend target.
 - Explain common Conda, Python, NAM, torch, and accelerator problems in plain language.
+- Catch real process-launch failures before the user queues a training job.
 - Provide copyable commands for the most likely fixes without forcing users to build commands by hand.
 - Export enough context for deeper troubleshooting in support threads or LLM tools when the built-in guidance is not enough.
 
@@ -27,9 +29,50 @@ The Diagnostics screen auto-loads its checks when the page opens.
 
 - backend validation runs if there is no current validation snapshot
 - accelerator diagnostics run if there is no current accelerator snapshot
-- the `Re-check` button refreshes both panels together
+- training launch diagnostics run if there is no current launch-readiness snapshot
+- the `Re-check All` button refreshes backend, accelerator, training launch, and NAM version checks together
 
 This keeps the page useful as a quick status check even when the user has not manually triggered anything yet.
+
+### Summary Tiles And Action Center
+
+The top of the screen shows four compact readiness tiles:
+
+- Backend
+- Accelerator
+- Training Launch
+- NAM Version
+
+Each tile shows a short status, a one-line result, and the latest check time when applicable.
+
+Below the tiles, Diagnostics shows one action center rather than a stack of separate troubleshooting panels.
+
+- If everything is ready, the action center reports `Ready To Train`.
+- If something needs attention, it chooses the highest-priority issue and shows what happened, what it likely means, how to fix it, and how to verify the fix.
+- Lower-priority issues are summarized as compact `Also detected` badges so the user is not forced to juggle many open sections.
+
+The priority order is:
+
+1. backend reachability problems
+2. Lightning security blocks
+3. training launch failures
+4. workspace/output path problems
+5. NAM installation or trainer command problems
+6. accelerator problems
+7. version/update advisories
+
+### Check Matrix
+
+The detailed results are shown as a compact check matrix instead of large repeated cards.
+
+The matrix groups rows by:
+
+- Backend
+- Training Launch
+- Accelerator
+- NAM Version
+
+Rows use `PASS`, `CHECK`, `FAIL`, and `SKIP` labels. Failed rows can include one-line guidance directly in the row, while full troubleshooting exports and raw facts stay in `Advanced Details`.
 
 ### Backend Diagnostics Panel
 
@@ -57,6 +100,35 @@ Each check shows:
 - a suggested next action when one is available
 
 This panel is meant to answer "Can NAM-BOT actually run the configured training environment at all?"
+
+### Training Launch Readiness
+
+The Training Launch check answers a different question from backend validation:
+
+"Can NAM-BOT launch the same terminal process path that real training uses?"
+
+This matters because backend validation uses short `child_process` checks, while real training uses `node-pty` so the app can stream terminal output. A machine can pass backend validation and still fail to launch training with an OS-level error such as `posix_spawnp failed`.
+
+Training launch diagnostics check:
+
+- Conda is reachable from the app
+- the selected backend mode is compatible with the current trainer launch path
+- NAM-BOT can create and write a temporary training workspace
+- a PTY can launch Python through `conda run --no-capture-output`
+- a PTY can launch `nam-full --help` through the same path
+- macOS app location warnings such as running from a DMG or app translocation
+- fragile Conda settings such as relying on bare `conda` instead of a full executable path
+
+The launch probe intentionally runs harmless commands. It does not start a training run or require a queued job.
+
+If launch readiness fails, Diagnostics should explain whether the likely problem is:
+
+- a bare or unreachable Conda executable
+- unsupported Direct Python launch mode
+- a blocked or unwritable workspace folder
+- a PTY launch failure before NAM starts
+- a `nam-full` launch failure through the training terminal path
+- macOS app location or architecture issues
 
 ### Accelerator Diagnostics Panel
 
@@ -144,6 +216,10 @@ The current guided paths cover cases such as:
 - CUDA not visible from the selected environment
 - torch and Lightning disagreeing about CUDA
 - probe execution failures
+- PTY launch failures such as `posix_spawnp failed`
+- NAM-BOT running from fragile macOS app locations such as a DMG or app translocation path
+- workspace folder creation/write failures
+- Conda configured as a bare command when a full executable path would be more reliable
 
 The commands are generated against the user's currently selected backend target, so the same screen works for:
 
@@ -172,6 +248,7 @@ It includes:
 - the active NAM-BOT backend configuration
 - backend validation results
 - accelerator diagnostics results
+- training launch readiness results
 - already-prepared verification and repair commands for the exact target environment
 
 The prompt explicitly asks the assistant for:
@@ -213,6 +290,17 @@ Start with the accelerator panel.
 - if the machine is Apple Silicon, pay attention to the reported `MPS available` field rather than NVIDIA host checks
 - if torch sees CUDA but Lightning does not, inspect package mismatch rather than reinstalling NAM immediately
 - if NAM-BOT reports a Lightning security block, repair the Python environment before running validation or training
+
+### If Backend Is Ready But Training Launch Fails
+
+Start with the Training Launch rows.
+
+- if `PTY Python launch` fails, the environment may be valid but the operating system or app runtime cannot start the training terminal process
+- if Conda is configured as `conda`, use the full Conda executable path from `which conda` on macOS/Linux or `where conda` on Windows
+- on macOS, move NAM-BOT into `/Applications`, right-click it, choose Open, and re-run Diagnostics
+- make sure the app build matches the CPU architecture, especially Apple Silicon `arm64`
+- set the Default Workspace Root to a local writable folder while troubleshooting
+- if Python launches but `nam-full` does not, repair or reinstall `neural-amp-modeler` in the same environment
 
 ### Lightning Security Block
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nam-bot",
-  "version": "0.5.1-rc.1",
+  "version": "0.5.1-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nam-bot",
-      "version": "0.5.1-rc.1",
+      "version": "0.5.1-rc.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nam-bot",
-  "version": "0.5.1-rc.1",
+  "version": "0.5.1-rc.2",
   "description": "Neural Amp Modeler Training Manager",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/backend/adapter.ts
+++ b/src/main/backend/adapter.ts
@@ -12,7 +12,11 @@ import {
   BackendCheckResult,
   BackendValidationSummary,
   CondaDiscoverySummary,
-  NamVersionInfo
+  NamVersionInfo,
+  TrainingLaunchCheckResult,
+  TrainingLaunchDiagnosticsIssue,
+  TrainingLaunchDiagnosticsStatus,
+  TrainingLaunchDiagnosticsSummary
 } from '../types'
 
 export interface RunHooks {
@@ -71,6 +75,19 @@ interface HostNvidiaSummary {
 
 const VULNERABLE_LIGHTNING_VERSIONS = new Set(['2.6.2', '2.6.3'])
 const LIGHTNING_SECURITY_PREFIX = 'NAM_BOT_LIGHTNING_SECURITY='
+const TRAINING_LAUNCH_PTY_PREFIX = 'NAM_BOT_PTY_OK'
+const TRAINING_LAUNCH_TIMEOUT_MS = 30_000
+const LIGHTNING_SECURITY_RECENT_RESULT_TTL_MS = 5_000
+const lightningSecurityInFlight = new Map<string, Promise<LightningSecuritySummary>>()
+const lightningSecurityRecentResults = new Map<string, { checkedAt: number; summary: LightningSecuritySummary }>()
+
+interface PtyCommandResult {
+  ok: boolean
+  output: string
+  exitCode: number | null
+  timedOut: boolean
+  errorMessage: string | null
+}
 
 export interface TrainingProcessController {
   cancel: () => void
@@ -146,6 +163,126 @@ function createAcceleratorDiagnosticsSummary(
     hostDriverVersion: extras?.hostDriverVersion ?? null,
     errors: extras?.errors ?? []
   }
+}
+
+function createTrainingLaunchCheck(
+  status: TrainingLaunchCheckResult['status'],
+  code: string,
+  title: string,
+  message: string,
+  extras?: Partial<Omit<TrainingLaunchCheckResult, 'status' | 'code' | 'title' | 'message'>>
+): TrainingLaunchCheckResult {
+  return {
+    status,
+    code,
+    title,
+    message,
+    detail: extras?.detail,
+    suggestion: extras?.suggestion,
+    command: extras?.command,
+    outputTail: extras?.outputTail
+  }
+}
+
+function createTrainingLaunchDiagnosticsSummary(
+  status: TrainingLaunchDiagnosticsStatus,
+  issue: TrainingLaunchDiagnosticsIssue,
+  headline: string,
+  detail: string,
+  extras?: Partial<Omit<TrainingLaunchDiagnosticsSummary, 'checkedAt' | 'status' | 'issue' | 'headline' | 'detail'>>
+): TrainingLaunchDiagnosticsSummary {
+  return {
+    checkedAt: new Date().toISOString(),
+    status,
+    issue,
+    headline,
+    detail,
+    suggestion: extras?.suggestion,
+    workspaceRoot: extras?.workspaceRoot ?? null,
+    workspacePath: extras?.workspacePath ?? null,
+    appExecutablePath: extras?.appExecutablePath ?? process.execPath,
+    processArch: extras?.processArch ?? process.arch,
+    checks: extras?.checks ?? [],
+    errors: extras?.errors ?? []
+  }
+}
+
+function tailOutput(output: string, maxLength = 2_000): string {
+  const trimmed = output.trim()
+  if (trimmed.length <= maxLength) {
+    return trimmed
+  }
+
+  return trimmed.slice(trimmed.length - maxLength)
+}
+
+function isBareExecutablePath(command: string): boolean {
+  return !command.includes('\\') && !command.includes('/')
+}
+
+function resolveWorkspaceRoot(settings: AppSettings): string {
+  const configuredRoot = settings.defaultWorkspaceRoot?.trim()
+  if (configuredRoot && configuredRoot.length > 0) {
+    return configuredRoot
+  }
+
+  return join(app.getPath('userData'), 'workspaces')
+}
+
+function formatCondaDiagnosticCommand(settings: AppSettings, args: string[]): string | undefined {
+  if (!settings.condaExecutablePath) {
+    return undefined
+  }
+
+  try {
+    return formatCommandForLog(
+      settings.condaExecutablePath,
+      buildCondaArgv(settings, args, { noCaptureOutput: true })
+    )
+  } catch {
+    return undefined
+  }
+}
+
+function createMacAppLocationCheck(): TrainingLaunchCheckResult | null {
+  if (process.platform !== 'darwin') {
+    return null
+  }
+
+  const executablePath = process.execPath
+  if (executablePath.includes('/AppTranslocation/')) {
+    return createTrainingLaunchCheck(
+      'warn',
+      'mac_app_translocated',
+      'App location',
+      'macOS appears to be running NAM-BOT from a translocated app path.',
+      {
+        detail: executablePath,
+        suggestion: 'Move NAM-BOT to /Applications, right-click it, choose Open, then re-run Diagnostics.'
+      }
+    )
+  }
+
+  if (executablePath.startsWith('/Volumes/')) {
+    return createTrainingLaunchCheck(
+      'warn',
+      'mac_app_on_dmg',
+      'App location',
+      'NAM-BOT appears to be running from a mounted DMG or external volume.',
+      {
+        detail: executablePath,
+        suggestion: 'Drag NAM-BOT into /Applications, open it from there, then re-run Diagnostics.'
+      }
+    )
+  }
+
+  return createTrainingLaunchCheck(
+    'pass',
+    'mac_app_location_ok',
+    'App location',
+    'NAM-BOT is not running from a common macOS translocation or DMG path.',
+    { detail: executablePath }
+  )
 }
 
 function hasMissingModuleMessage(errors: string[], moduleName: string): boolean {
@@ -363,6 +500,71 @@ function spawnCondaPty(
     cwd: options?.cwd,
     env: createTrainingEnv(),
     useConpty: process.platform === 'win32'
+  })
+}
+
+function runCondaPtyCommand(
+  settings: AppSettings,
+  args: string[],
+  options?: { cwd?: string; timeoutMs?: number }
+): Promise<PtyCommandResult> {
+  return new Promise((resolve) => {
+    let pty: IPty
+    try {
+      pty = spawnCondaPty(settings, args, { cwd: options?.cwd })
+    } catch (error) {
+      resolve({
+        ok: false,
+        output: '',
+        exitCode: null,
+        timedOut: false,
+        errorMessage: error instanceof Error ? error.message : 'PTY process launch failed'
+      })
+      return
+    }
+
+    let output = ''
+    let settled = false
+    const timeoutMs = options?.timeoutMs ?? TRAINING_LAUNCH_TIMEOUT_MS
+    let timeout: NodeJS.Timeout
+
+    const settle = (result: PtyCommandResult): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      resolve(result)
+    }
+
+    timeout = setTimeout(() => {
+      void forceKillPtyProcessTree(pty).finally(() => {
+        settle({
+          ok: false,
+          output,
+          exitCode: null,
+          timedOut: true,
+          errorMessage: 'PTY command timed out'
+        })
+      })
+    }, timeoutMs)
+
+    pty.onData((data: string) => {
+      output += data
+      if (output.length > 20_000) {
+        output = output.slice(output.length - 20_000)
+      }
+    })
+
+    pty.onExit(({ exitCode }) => {
+      settle({
+        ok: exitCode === 0,
+        output,
+        exitCode,
+        timedOut: false,
+        errorMessage: null
+      })
+    })
   })
 }
 
@@ -769,7 +971,17 @@ async function runPythonScriptInEnvironment(
   }
 }
 
-async function inspectLightningPackageSecurity(settings: AppSettings): Promise<LightningSecuritySummary> {
+function getLightningSecurityCacheKey(settings: AppSettings): string {
+  return JSON.stringify({
+    backendMode: settings.backendMode,
+    condaExecutablePath: settings.condaExecutablePath ?? null,
+    environmentName: settings.environmentName ?? null,
+    environmentPrefixPath: settings.environmentPrefixPath ?? null,
+    pythonExecutablePath: settings.pythonExecutablePath ?? null
+  })
+}
+
+async function runLightningPackageSecurityProbe(settings: AppSettings): Promise<LightningSecuritySummary> {
   const script = [
     'import json',
     'from importlib.metadata import PackageNotFoundError, version',
@@ -830,8 +1042,38 @@ async function inspectLightningPackageSecurity(settings: AppSettings): Promise<L
   }
 }
 
+async function inspectLightningPackageSecurity(
+  settings: AppSettings,
+  options?: { allowRecentResult?: boolean }
+): Promise<LightningSecuritySummary> {
+  const cacheKey = getLightningSecurityCacheKey(settings)
+  const allowRecentResult = options?.allowRecentResult ?? true
+  const recentResult = lightningSecurityRecentResults.get(cacheKey)
+  if (allowRecentResult && recentResult && Date.now() - recentResult.checkedAt < LIGHTNING_SECURITY_RECENT_RESULT_TTL_MS) {
+    log.info('Reusing recent Lightning security probe result')
+    return recentResult.summary
+  }
+
+  const inFlight = lightningSecurityInFlight.get(cacheKey)
+  if (inFlight) {
+    log.info('Reusing in-flight Lightning security probe')
+    return inFlight
+  }
+
+  const probe = runLightningPackageSecurityProbe(settings)
+    .then((summary) => {
+      lightningSecurityRecentResults.set(cacheKey, { checkedAt: Date.now(), summary })
+      return summary
+    })
+    .finally(() => {
+      lightningSecurityInFlight.delete(cacheKey)
+    })
+  lightningSecurityInFlight.set(cacheKey, probe)
+  return probe
+}
+
 async function assertLightningPackageSafe(settings: AppSettings): Promise<void> {
-  const lightningSecurity = await inspectLightningPackageSecurity(settings)
+  const lightningSecurity = await inspectLightningPackageSecurity(settings, { allowRecentResult: false })
   if (!lightningSecurity.ok) {
     throw new Error('NAM-BOT could not verify Lightning package versions safely. Verify package metadata manually before running NAM commands in this environment.')
   }
@@ -1246,6 +1488,479 @@ export async function inspectAcceleratorDiagnostics(
         : 'Check the NVIDIA driver, confirm the GPU is visible on the host, and make sure NAM-BOT is pointing at the environment where the CUDA-enabled PyTorch build is installed.'
     }
   )
+}
+
+export async function inspectTrainingLaunchDiagnostics(
+  settings: AppSettings
+): Promise<TrainingLaunchDiagnosticsSummary> {
+  const checks: TrainingLaunchCheckResult[] = []
+  const appLocationCheck = createMacAppLocationCheck()
+  if (appLocationCheck) {
+    checks.push(appLocationCheck)
+  }
+
+  if (settings.backendMode === 'direct-python') {
+    checks.push(
+      createTrainingLaunchCheck(
+        'fail',
+        'direct_python_unsupported',
+        'Training launch mode',
+        'Direct Python mode is not supported by the current training launch path.',
+        {
+          detail: settings.pythonExecutablePath ?? 'No Python executable configured',
+          suggestion: 'Use Conda environment name or Conda prefix mode for training launch readiness.'
+        }
+      ),
+      createTrainingLaunchCheck('skip', 'pty_python_skipped', 'PTY Python launch', 'Skipped because direct Python launch is not wired to the trainer yet.'),
+      createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped because direct Python launch is not wired to the trainer yet.')
+    )
+
+    return createTrainingLaunchDiagnosticsSummary(
+      'error',
+      'direct_python_unsupported',
+      'Training launch is not ready',
+      'NAM-BOT currently launches training through Conda, but Settings is using Direct Python mode.',
+      {
+        checks,
+        suggestion: 'Switch Settings to a Conda environment name or prefix before training.'
+      }
+    )
+  }
+
+  const condaExecutablePath = settings.condaExecutablePath?.trim() ?? ''
+  if (!condaExecutablePath) {
+    checks.push(
+      createTrainingLaunchCheck(
+        'fail',
+        'conda_not_configured',
+        'Conda executable',
+        'No Conda executable is configured.',
+        { suggestion: 'Open Settings and select your Conda executable before running training.' }
+      ),
+      createTrainingLaunchCheck('skip', 'workspace_skipped', 'Workspace write', 'Skipped until Conda is configured.'),
+      createTrainingLaunchCheck('skip', 'pty_python_skipped', 'PTY Python launch', 'Skipped until Conda is configured.'),
+      createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped until Conda is configured.')
+    )
+
+    return createTrainingLaunchDiagnosticsSummary(
+      'not_checked',
+      'conda_not_configured',
+      'Training launch was not checked',
+      'Configure Conda before NAM-BOT can test the real training launch path.',
+      {
+        checks,
+        suggestion: 'Open Settings and select your Conda executable.'
+      }
+    )
+  }
+
+  if (!(await isConfiguredCondaReachable(condaExecutablePath))) {
+    checks.push(
+      createTrainingLaunchCheck(
+        'fail',
+        'conda_unreachable',
+        'Conda executable',
+        `Conda is not reachable at ${condaExecutablePath}.`,
+        { suggestion: 'Use the full Conda executable path in Settings, then re-run Diagnostics.' }
+      ),
+      createTrainingLaunchCheck('skip', 'workspace_skipped', 'Workspace write', 'Skipped until Conda is reachable.'),
+      createTrainingLaunchCheck('skip', 'pty_python_skipped', 'PTY Python launch', 'Skipped until Conda is reachable.'),
+      createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped until Conda is reachable.')
+    )
+
+    return createTrainingLaunchDiagnosticsSummary(
+      'not_checked',
+      'conda_unreachable',
+      'Training launch was not checked',
+      'NAM-BOT cannot test the training launch path until Conda is reachable.',
+      {
+        checks,
+        suggestion: 'Fix the Conda executable path in Settings.'
+      }
+    )
+  }
+
+  checks.push(
+    createTrainingLaunchCheck(
+      'pass',
+      'conda_reachable',
+      'Conda executable',
+      'Conda is reachable for launch testing.',
+      { detail: condaExecutablePath }
+    )
+  )
+
+  if (process.platform !== 'win32' && isBareExecutablePath(condaExecutablePath)) {
+    checks.push(
+      createTrainingLaunchCheck(
+        'warn',
+        'bare_conda_path',
+        'Conda path style',
+        `Conda is configured as "${condaExecutablePath}" instead of a full executable path.`,
+        { suggestion: 'If launch fails on this machine, paste the full Conda path into Settings instead of relying on PATH.' }
+      )
+    )
+  }
+
+  if (settings.backendMode === 'conda-name' && !settings.environmentName) {
+    checks.push(
+      createTrainingLaunchCheck(
+        'fail',
+        'environment_not_configured',
+        'Conda environment',
+        'No Conda environment name is configured.',
+        { suggestion: 'Set the Conda environment name in Settings.' }
+      ),
+      createTrainingLaunchCheck('skip', 'pty_python_skipped', 'PTY Python launch', 'Skipped until the Conda environment is configured.'),
+      createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped until the Conda environment is configured.')
+    )
+
+    return createTrainingLaunchDiagnosticsSummary(
+      'not_checked',
+      'environment_not_configured',
+      'Training launch was not checked',
+      'Choose a Conda environment before NAM-BOT can test the real training launch path.',
+      { checks, suggestion: 'Set the Conda environment name in Settings.' }
+    )
+  }
+
+  if (settings.backendMode === 'conda-prefix' && !settings.environmentPrefixPath) {
+    checks.push(
+      createTrainingLaunchCheck(
+        'fail',
+        'environment_not_configured',
+        'Conda environment',
+        'No Conda environment prefix is configured.',
+        { suggestion: 'Set the Conda environment prefix path in Settings.' }
+      ),
+      createTrainingLaunchCheck('skip', 'pty_python_skipped', 'PTY Python launch', 'Skipped until the Conda environment is configured.'),
+      createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped until the Conda environment is configured.')
+    )
+
+    return createTrainingLaunchDiagnosticsSummary(
+      'not_checked',
+      'environment_not_configured',
+      'Training launch was not checked',
+      'Choose a Conda environment prefix before NAM-BOT can test the real training launch path.',
+      { checks, suggestion: 'Set the Conda environment prefix path in Settings.' }
+    )
+  }
+
+  const lightningSecurity = await inspectLightningPackageSecurity(settings)
+  const vulnerableLightningPackage = lightningSecurity.ok ? getVulnerableLightningPackage(lightningSecurity) : null
+  if (!lightningSecurity.ok || vulnerableLightningPackage) {
+    const detail = vulnerableLightningPackage
+      ? createLightningSecurityDetail(vulnerableLightningPackage)
+      : 'NAM-BOT could not verify Lightning package metadata safely.'
+    checks.push(
+      createTrainingLaunchCheck(
+        'fail',
+        vulnerableLightningPackage ? 'lightning_vulnerable' : 'lightning_security_check_failed',
+        'Lightning safety',
+        vulnerableLightningPackage ? `${vulnerableLightningPackage.name} ${vulnerableLightningPackage.version} is blocked.` : 'Lightning package safety could not be verified.',
+        {
+          detail,
+          suggestion: createLightningSecuritySuggestion(),
+          outputTail: tailOutput(lightningSecurity.output)
+        }
+      ),
+      createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped until Lightning package safety is resolved.')
+    )
+
+    return createTrainingLaunchDiagnosticsSummary(
+      'error',
+      vulnerableLightningPackage ? 'lightning_vulnerable' : 'lightning_security_check_failed',
+      'Training launch is blocked',
+      detail,
+      {
+        checks,
+        suggestion: createLightningSecuritySuggestion(),
+        errors: [lightningSecurity.output.trim()].filter((entry) => entry.length > 0)
+      }
+    )
+  }
+
+  const workspaceRoot = resolveWorkspaceRoot(settings)
+  let workspacePath: string | null = null
+
+  try {
+    if (!existsSync(workspaceRoot)) {
+      mkdirSync(workspaceRoot, { recursive: true })
+    }
+    workspacePath = mkdtempSync(join(workspaceRoot, 'diagnostics-'))
+    const writeProbePath = join(workspacePath, 'write-test.txt')
+    writeFileSync(writeProbePath, 'NAM_BOT_WORKSPACE_OK', 'utf8')
+    rmSync(writeProbePath, { force: true })
+    checks.push(
+      createTrainingLaunchCheck(
+        'pass',
+        'workspace_writable',
+        'Workspace write',
+        'NAM-BOT can create and write to a temporary training workspace.',
+        { detail: workspacePath }
+      )
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Workspace write failed'
+    checks.push(
+      createTrainingLaunchCheck(
+        'fail',
+        'workspace_unwritable',
+        'Workspace write',
+        'NAM-BOT could not create or write to the training workspace.',
+        {
+          detail: message,
+          suggestion: 'Set Default Workspace Root to a local writable folder in Settings.'
+        }
+      ),
+      createTrainingLaunchCheck('skip', 'pty_python_skipped', 'PTY Python launch', 'Skipped until the training workspace is writable.'),
+      createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped until the training workspace is writable.')
+    )
+
+    return createTrainingLaunchDiagnosticsSummary(
+      'error',
+      'workspace_unwritable',
+      'Training workspace is not writable',
+      'NAM-BOT must be able to create a workspace before it can launch training.',
+      {
+        workspaceRoot,
+        workspacePath,
+        checks,
+        suggestion: 'Choose a local writable Default Workspace Root in Settings.',
+        errors: [message]
+      }
+    )
+  }
+
+  try {
+    const pythonArgs = ['python', '-c', `print('${TRAINING_LAUNCH_PTY_PREFIX}')`]
+    const pythonCommand = formatCondaDiagnosticCommand(settings, pythonArgs)
+    const pythonResult = await runCondaPtyCommand(settings, pythonArgs, { cwd: workspacePath })
+
+    if (pythonResult.timedOut) {
+      checks.push(
+        createTrainingLaunchCheck(
+          'fail',
+          'pty_launch_timeout',
+          'PTY Python launch',
+          'The training-style terminal launch timed out before Python responded.',
+          {
+            command: pythonCommand,
+            outputTail: tailOutput(pythonResult.output),
+            suggestion: 'Conda may be slow or stuck. Re-run Diagnostics, and if it repeats, verify the environment manually in Terminal.'
+          }
+        ),
+        createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped until PTY Python launch works.')
+      )
+
+      return createTrainingLaunchDiagnosticsSummary(
+        'error',
+        'pty_launch_timeout',
+        'Training launch timed out',
+        'NAM-BOT could not confirm that the training terminal launch path can start Python in time.',
+        {
+          workspaceRoot,
+          workspacePath,
+          checks,
+          suggestion: 'Try again once. If it still times out, inspect the Conda environment from Terminal.',
+          errors: [tailOutput(pythonResult.output)].filter((entry) => entry.length > 0)
+        }
+      )
+    }
+
+    if (!pythonResult.ok) {
+      const errorDetail = pythonResult.errorMessage ?? (tailOutput(pythonResult.output) || 'PTY launch failed')
+      checks.push(
+        createTrainingLaunchCheck(
+          'fail',
+          'pty_launch_failed',
+          'PTY Python launch',
+          'NAM-BOT could not start the terminal process used for training.',
+          {
+            detail: errorDetail,
+            command: pythonCommand,
+            outputTail: tailOutput(pythonResult.output),
+            suggestion: isBareExecutablePath(condaExecutablePath)
+              ? 'Use the full Conda executable path in Settings instead of relying on PATH.'
+              : 'Move the app to a normal local application folder and verify that security software is not blocking child processes.'
+          }
+        ),
+        createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped until PTY Python launch works.')
+      )
+
+      return createTrainingLaunchDiagnosticsSummary(
+        'error',
+        'pty_launch_failed',
+        'Training launch failed before NAM started',
+        'The configured environment passed basic checks, but NAM-BOT could not start the same terminal process used by real training.',
+        {
+          workspaceRoot,
+          workspacePath,
+          checks,
+          suggestion: isBareExecutablePath(condaExecutablePath)
+            ? 'Paste the full Conda executable path into Settings, then re-run Diagnostics.'
+            : 'Check the app location, app architecture, workspace folder, and security software.',
+          errors: [errorDetail]
+        }
+      )
+    }
+
+    if (!pythonResult.output.includes(TRAINING_LAUNCH_PTY_PREFIX)) {
+      checks.push(
+        createTrainingLaunchCheck(
+          'fail',
+          'pty_payload_missing',
+          'PTY Python launch',
+          'The terminal process started, but Python did not return the expected readiness marker.',
+          {
+            command: pythonCommand,
+            outputTail: tailOutput(pythonResult.output),
+            suggestion: 'Inspect the output below and verify the selected Conda environment can run Python cleanly.'
+          }
+        ),
+        createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped until PTY Python launch returns the expected marker.')
+      )
+
+      return createTrainingLaunchDiagnosticsSummary(
+        'error',
+        'pty_payload_missing',
+        'Training launch returned unexpected output',
+        'NAM-BOT started the training terminal process, but did not receive the expected readiness marker from Python.',
+        {
+          workspaceRoot,
+          workspacePath,
+          checks,
+          suggestion: 'Verify Python in the selected environment and re-run Diagnostics.',
+          errors: [tailOutput(pythonResult.output)].filter((entry) => entry.length > 0)
+        }
+      )
+    }
+
+    checks.push(
+      createTrainingLaunchCheck(
+        'pass',
+        'pty_python_ok',
+        'PTY Python launch',
+        'NAM-BOT can launch Python through the same terminal path used for training.',
+        { command: pythonCommand }
+      )
+    )
+
+    const namFullArgs = ['nam-full', '--help']
+    const namFullCommand = formatCondaDiagnosticCommand(settings, namFullArgs)
+    const namFullResult = await runCondaPtyCommand(settings, namFullArgs, { cwd: workspacePath })
+    const namFullOutput = namFullResult.output
+    const namFullHelpOk = namFullResult.ok || namFullOutput.includes('usage') || namFullOutput.includes('Options')
+
+    if (namFullResult.timedOut) {
+      checks.push(
+        createTrainingLaunchCheck(
+          'fail',
+          'nam_full_pty_timeout',
+          'nam-full PTY launch',
+          'The trainer command timed out when launched through the training terminal path.',
+          {
+            command: namFullCommand,
+            outputTail: tailOutput(namFullOutput),
+            suggestion: 'Re-run Diagnostics. If it repeats, verify that nam-full --help returns promptly in Terminal.'
+          }
+        )
+      )
+
+      return createTrainingLaunchDiagnosticsSummary(
+        'error',
+        'nam_full_pty_timeout',
+        'Trainer launch timed out',
+        'Python can launch through NAM-BOT, but the NAM trainer command did not return in time.',
+        {
+          workspaceRoot,
+          workspacePath,
+          checks,
+          suggestion: 'Repair or reinstall neural-amp-modeler in this environment if nam-full hangs in Terminal too.',
+          errors: [tailOutput(namFullOutput)].filter((entry) => entry.length > 0)
+        }
+      )
+    }
+
+    if (!namFullHelpOk) {
+      const errorDetail = namFullResult.errorMessage ?? (tailOutput(namFullOutput) || 'nam-full launch failed')
+      checks.push(
+        createTrainingLaunchCheck(
+          'fail',
+          'nam_full_pty_failed',
+          'nam-full PTY launch',
+          'NAM-BOT could not launch the NAM trainer command through the training terminal path.',
+          {
+            detail: errorDetail,
+            command: namFullCommand,
+            outputTail: tailOutput(namFullOutput),
+            suggestion: 'Repair neural-amp-modeler in this environment, then re-run Diagnostics.'
+          }
+        )
+      )
+
+      return createTrainingLaunchDiagnosticsSummary(
+        'error',
+        'nam_full_pty_failed',
+        'Trainer command is not launch-ready',
+        'The terminal launch path works for Python, but not for the NAM trainer command.',
+        {
+          workspaceRoot,
+          workspacePath,
+          checks,
+          suggestion: 'Install or repair neural-amp-modeler in this same environment.',
+          errors: [errorDetail]
+        }
+      )
+    }
+
+    checks.push(
+      createTrainingLaunchCheck(
+        'pass',
+        'nam_full_pty_ok',
+        'nam-full PTY launch',
+        'NAM-BOT can launch the NAM trainer command through the training terminal path.',
+        { command: namFullCommand }
+      )
+    )
+
+    const warningCheck = checks.find((check) => check.status === 'warn')
+    if (warningCheck) {
+      const issue: TrainingLaunchDiagnosticsIssue =
+        warningCheck.code === 'mac_app_on_dmg' || warningCheck.code === 'mac_app_translocated' || warningCheck.code === 'bare_conda_path'
+          ? warningCheck.code
+          : 'bare_conda_path'
+
+      return createTrainingLaunchDiagnosticsSummary(
+        'advisory',
+        issue,
+        'Training launch works with advisory notes',
+        'NAM-BOT can launch the training path, but one setup detail may be fragile on some machines.',
+        {
+          workspaceRoot,
+          workspacePath,
+          checks,
+          suggestion: warningCheck.suggestion
+        }
+      )
+    }
+
+    return createTrainingLaunchDiagnosticsSummary(
+      'ready',
+      'ready',
+      'Training launch is ready',
+      'NAM-BOT can create a training workspace and launch the NAM trainer through the same terminal path used by real jobs.',
+      {
+        workspaceRoot,
+        workspacePath,
+        checks
+      }
+    )
+  } finally {
+    if (workspacePath) {
+      rmSync(workspacePath, { recursive: true, force: true })
+    }
+  }
 }
 
 export async function runNamHelloWorld(

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -1,7 +1,13 @@
 import { ipcMain, dialog, BrowserWindow } from 'electron'
 import log from 'electron-log/main'
 import { loadSettings, saveSettings } from '../persistence/settingsStore'
-import { detectCondaOnPath, getNamVersionInfo, inspectAcceleratorDiagnostics, validateBackend } from '../backend/adapter'
+import {
+  detectCondaOnPath,
+  getNamVersionInfo,
+  inspectAcceleratorDiagnostics,
+  inspectTrainingLaunchDiagnostics,
+  validateBackend
+} from '../backend/adapter'
 import { AppSettings, NamVersionInfo } from '../types'
 import { getQueueManager } from '../jobs/queueManager'
 
@@ -73,6 +79,17 @@ export function setupIpcHandlers(): void {
       return await inspectAcceleratorDiagnostics(settings)
     } catch (error) {
       log.error('Failed to inspect accelerator diagnostics:', error)
+      throw error
+    }
+  })
+
+  ipcMain.handle('settings:getTrainingLaunchDiagnostics', async () => {
+    try {
+      const settings: AppSettings = cachedSettings || loadSettings()
+      cachedSettings = settings
+      return await inspectTrainingLaunchDiagnostics(settings)
+    } catch (error) {
+      log.error('Failed to inspect training launch diagnostics:', error)
       throw error
     }
   })

--- a/src/main/types/index.ts
+++ b/src/main/types/index.ts
@@ -110,6 +110,59 @@ export interface AcceleratorDiagnosticsSummary {
   errors: string[]
 }
 
+export type TrainingLaunchDiagnosticsStatus =
+  | 'ready'
+  | 'advisory'
+  | 'not_checked'
+  | 'error'
+
+export type TrainingLaunchDiagnosticsIssue =
+  | 'ready'
+  | 'not_checked'
+  | 'conda_not_configured'
+  | 'conda_unreachable'
+  | 'environment_not_configured'
+  | 'direct_python_unsupported'
+  | 'lightning_security_check_failed'
+  | 'lightning_vulnerable'
+  | 'workspace_unwritable'
+  | 'pty_launch_failed'
+  | 'pty_launch_timeout'
+  | 'pty_payload_missing'
+  | 'nam_full_pty_failed'
+  | 'nam_full_pty_timeout'
+  | 'mac_app_on_dmg'
+  | 'mac_app_translocated'
+  | 'bare_conda_path'
+
+export type TrainingLaunchCheckStatus = 'pass' | 'warn' | 'fail' | 'skip'
+
+export interface TrainingLaunchCheckResult {
+  status: TrainingLaunchCheckStatus
+  code: string
+  title: string
+  message: string
+  detail?: string
+  suggestion?: string
+  command?: string
+  outputTail?: string
+}
+
+export interface TrainingLaunchDiagnosticsSummary {
+  checkedAt: string
+  status: TrainingLaunchDiagnosticsStatus
+  issue: TrainingLaunchDiagnosticsIssue
+  headline: string
+  detail: string
+  suggestion?: string
+  workspaceRoot: string | null
+  workspacePath: string | null
+  appExecutablePath: string | null
+  processArch: string
+  checks: TrainingLaunchCheckResult[]
+  errors: string[]
+}
+
 export interface CondaDiscoverySummary {
   checkedAt: string
   isOnPath: boolean

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,7 @@ export interface NamBotApi {
     validate: () => Promise<unknown>
     detectConda: () => Promise<unknown>
     getAcceleratorDiagnostics: () => Promise<unknown>
+    getTrainingLaunchDiagnostics: () => Promise<unknown>
     getNamVersionInfo: () => Promise<unknown>
     chooseCondaPath: () => Promise<string | null>
     chooseDirectory: () => Promise<string | null>
@@ -74,6 +75,7 @@ const api: NamBotApi = {
     validate: () => ipcRenderer.invoke('settings:validate'),
     detectConda: () => ipcRenderer.invoke('settings:detectConda'),
     getAcceleratorDiagnostics: () => ipcRenderer.invoke('settings:getAcceleratorDiagnostics'),
+    getTrainingLaunchDiagnostics: () => ipcRenderer.invoke('settings:getTrainingLaunchDiagnostics'),
     getNamVersionInfo: () => ipcRenderer.invoke('settings:getNamVersionInfo'),
     chooseCondaPath: () => ipcRenderer.invoke('settings:chooseCondaPath'),
     chooseDirectory: () => ipcRenderer.invoke('settings:chooseDirectory'),

--- a/src/renderer/features/diagnostics/Diagnostics.tsx
+++ b/src/renderer/features/diagnostics/Diagnostics.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
   AcceleratorDiagnosticsSummary,
   AppSettings,
   BackendCheckResult,
   BackendValidationSummary,
   NamVersionInfo,
+  TrainingLaunchCheckResult,
+  TrainingLaunchDiagnosticsSummary,
   useAppStore
 } from '../../state/store'
 
@@ -39,6 +42,7 @@ interface DiagnosticsExportPayload {
   }
   validation: BackendValidationSummary | null
   acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null
+  trainingLaunchDiagnostics: TrainingLaunchDiagnosticsSummary | null
   commands: {
     verifyPython: string
     verifyTorch: string
@@ -568,10 +572,28 @@ function formatBackendResultForPrompt(result: BackendCheckResult): string {
   return `- ${result.title}: ${parts.join(' | ')}`
 }
 
+function formatTrainingLaunchResultForPrompt(result: TrainingLaunchCheckResult): string {
+  const parts: string[] = [`${result.status.toUpperCase()} (${result.code})`, compactText(result.message)]
+  if (result.detail) {
+    parts.push(`detail: ${compactText(result.detail)}`)
+  }
+  if (result.suggestion) {
+    parts.push(`suggestion: ${compactText(result.suggestion)}`)
+  }
+  if (result.command) {
+    parts.push(`command: ${result.command}`)
+  }
+  if (result.outputTail) {
+    parts.push(`output tail: ${compactText(result.outputTail)}`)
+  }
+  return `- ${result.title}: ${parts.join(' | ')}`
+}
+
 function buildDiagnosticsExportPayload(
   settings: AppSettings | null,
   validation: BackendValidationSummary | null,
-  acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null
+  acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null,
+  trainingLaunchDiagnostics: TrainingLaunchDiagnosticsSummary | null
 ): DiagnosticsExportPayload {
   const commands = getDiagnosticCommands(settings)
   return {
@@ -592,6 +614,7 @@ function buildDiagnosticsExportPayload(
     },
     validation,
     acceleratorDiagnostics,
+    trainingLaunchDiagnostics,
     commands: {
       verifyPython: commands.verifyPython,
       verifyTorch: commands.verifyTorch,
@@ -610,7 +633,8 @@ function buildDiagnosticsExportPayload(
 function buildAiTroubleshootingPrompt(
   settings: AppSettings | null,
   validation: BackendValidationSummary | null,
-  acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null
+  acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null,
+  trainingLaunchDiagnostics: TrainingLaunchDiagnosticsSummary | null
 ): string {
   const commands = getDiagnosticCommands(settings)
   const backendLines = validation
@@ -653,6 +677,21 @@ function buildAiTroubleshootingPrompt(
       ].join('\n')
     : '- No accelerator diagnostics available.'
 
+  const trainingLaunchLines = trainingLaunchDiagnostics
+    ? [
+        `- Status: ${trainingLaunchDiagnostics.status}`,
+        `- Issue: ${trainingLaunchDiagnostics.issue}`,
+        `- Headline: ${compactText(trainingLaunchDiagnostics.headline)}`,
+        `- Detail: ${compactText(trainingLaunchDiagnostics.detail)}`,
+        `- Suggestion: ${compactText(trainingLaunchDiagnostics.suggestion, 'None')}`,
+        `- Workspace root: ${formatMaybeText(trainingLaunchDiagnostics.workspaceRoot, 'Not reported')}`,
+        `- App executable: ${formatMaybeText(trainingLaunchDiagnostics.appExecutablePath, 'Not reported')}`,
+        `- Process arch: ${trainingLaunchDiagnostics.processArch}`,
+        ...trainingLaunchDiagnostics.checks.map(formatTrainingLaunchResultForPrompt),
+        `- Launch errors: ${trainingLaunchDiagnostics.errors.length > 0 ? trainingLaunchDiagnostics.errors.map((entry) => compactText(entry)).join(' || ') : 'None'}`
+      ].join('\n')
+    : '- No training launch diagnostics available.'
+
   return [
     'I am troubleshooting a NAM-BOT local training environment.',
     'The user is likely a novice, so explain the root cause plainly and give step-by-step commands.',
@@ -677,6 +716,9 @@ function buildAiTroubleshootingPrompt(
     '',
     'Accelerator diagnostics',
     acceleratorLines,
+    '',
+    'Training launch diagnostics',
+    trainingLaunchLines,
     '',
     'Useful commands already prepared for this exact NAM-BOT target',
     `- Verify Python target: ${commands.verifyPython}`,
@@ -798,56 +840,683 @@ function shouldShowTroubleshootingExport(
   return acceleratorDiagnostics.status !== 'ready'
 }
 
+type MatrixStatus = 'pass' | 'warn' | 'fail' | 'skip'
+
+interface SummaryTile {
+  title: string
+  status: MatrixStatus
+  label: string
+  detail: string
+  checkedAt: string | null
+}
+
+interface MatrixRow {
+  status: MatrixStatus
+  title: string
+  message: string
+  detail?: string
+  suggestion?: string
+  command?: string
+  outputTail?: string
+}
+
+interface MatrixGroup {
+  title: string
+  rows: MatrixRow[]
+}
+
+interface ActionItem {
+  title: string
+  headline: string
+  body: string
+  steps: string[]
+  commands: CopyableCodeBlockProps[]
+  verify: string
+  tone: MatrixStatus
+}
+
+function getStatusColor(status: MatrixStatus): string {
+  switch (status) {
+    case 'pass':
+      return 'var(--neon-green)'
+    case 'warn':
+      return 'var(--neon-cyan)'
+    case 'fail':
+      return 'var(--neon-magenta)'
+    case 'skip':
+    default:
+      return 'var(--text-steel)'
+  }
+}
+
+function getStatusLabel(status: MatrixStatus): string {
+  switch (status) {
+    case 'pass':
+      return 'PASS'
+    case 'warn':
+      return 'CHECK'
+    case 'fail':
+      return 'FAIL'
+    case 'skip':
+    default:
+      return 'SKIP'
+  }
+}
+
+function SummaryTileCard({ tile }: { tile: SummaryTile }) {
+  const color = getStatusColor(tile.status)
+  return (
+    <div
+      style={{
+        border: `2px solid ${color}`,
+        backgroundColor: 'rgba(9, 9, 11, 0.55)',
+        padding: '12px',
+        minHeight: '118px',
+        display: 'grid',
+        alignContent: 'space-between',
+        gap: '8px'
+      }}
+    >
+      <div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '8px', alignItems: 'baseline', marginBottom: '8px' }}>
+          <p style={{ color: 'var(--text-steel)', fontSize: '10px', letterSpacing: '0.12em', textTransform: 'uppercase' }}>{tile.title}</p>
+          <span style={{ color, fontFamily: 'var(--font-arcade)', fontSize: '16px' }}>{getStatusLabel(tile.status)}</span>
+        </div>
+        <p style={{ color, fontFamily: 'var(--font-arcade)', fontSize: '22px', lineHeight: 1.05, marginBottom: '6px' }}>{tile.label}</p>
+        <p style={{ color: 'var(--text-steel)', fontSize: '12px', lineHeight: 1.35 }}>{tile.detail}</p>
+      </div>
+      <p style={{ color: 'var(--text-steel)', fontSize: '10px' }}>{tile.checkedAt ? `Checked ${new Date(tile.checkedAt).toLocaleTimeString()}` : 'Not checked yet'}</p>
+    </div>
+  )
+}
+
+function DiagnosticMatrixRow({ row }: { row: MatrixRow }) {
+  const color = getStatusColor(row.status)
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '70px minmax(150px, 220px) minmax(0, 1fr)',
+        gap: '12px',
+        padding: '9px 10px',
+        borderBottom: '1px solid rgba(255,255,255,0.08)',
+        backgroundColor: row.status === 'fail' ? 'rgba(255, 0, 60, 0.06)' : 'rgba(9, 9, 11, 0.25)'
+      }}
+    >
+      <span style={{ color, fontFamily: 'var(--font-arcade)', fontSize: '16px' }}>{getStatusLabel(row.status)}</span>
+      <span style={{ color: 'var(--text-ash)', fontFamily: 'var(--font-arcade)', fontSize: '16px' }}>{row.title}</span>
+      <div style={{ minWidth: 0 }}>
+        <p style={{ color: 'var(--text-steel)', fontSize: '13px', lineHeight: 1.35 }}>{row.message}</p>
+        {row.detail && <p style={{ color: 'var(--text-steel)', fontSize: '11px', lineHeight: 1.35, marginTop: '4px', wordBreak: 'break-word' }}>{row.detail}</p>}
+        {row.suggestion && <p style={{ color: 'var(--neon-cyan)', fontSize: '12px', lineHeight: 1.35, marginTop: '4px' }}>→ {row.suggestion}</p>}
+        {row.outputTail && <p style={{ color: 'var(--neon-gold)', fontSize: '11px', lineHeight: 1.35, marginTop: '4px', wordBreak: 'break-word' }}>{row.outputTail}</p>}
+      </div>
+    </div>
+  )
+}
+
+function DiagnosticMatrix({ groups }: { groups: MatrixGroup[] }) {
+  return (
+    <div className="panel" style={{ marginBottom: '16px' }}>
+      <div className="panel-header" style={{ marginBottom: '10px' }}>
+        <h3>Check Matrix</h3>
+      </div>
+      <div style={{ display: 'grid', gap: '12px' }}>
+        {groups.map((group) => (
+          <div key={group.title} style={{ border: '1px solid var(--border-dim)' }}>
+            <div style={{ padding: '7px 10px', borderBottom: '1px solid var(--border-dim)', backgroundColor: 'rgba(9, 9, 11, 0.55)' }}>
+              <p style={{ color: 'var(--neon-cyan)', fontFamily: 'var(--font-arcade)', fontSize: '18px', letterSpacing: '0.05em' }}>{group.title}</p>
+            </div>
+            {group.rows.map((row) => <DiagnosticMatrixRow key={`${group.title}-${row.title}-${row.message}`} row={row} />)}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function getBackendRows(validation: BackendValidationSummary | null): MatrixRow[] {
+  if (!validation) {
+    return [{ status: 'skip', title: 'Backend checks', message: 'Waiting for backend validation results.' }]
+  }
+
+  return [
+    validation.condaReachable,
+    validation.environmentReachable,
+    validation.pythonReachable,
+    validation.namInstalled,
+    validation.namFullAvailable
+  ].map((result) => ({
+    status: result.ok ? 'pass' : result.message === 'Not checked' || result.code === 'unknown' ? 'skip' : 'fail',
+    title: result.title,
+    message: result.message,
+    detail: result.detail,
+    suggestion: result.suggestion
+  }))
+}
+
+function getTrainingLaunchRows(trainingLaunchDiagnostics: TrainingLaunchDiagnosticsSummary | null): MatrixRow[] {
+  if (!trainingLaunchDiagnostics) {
+    return [{ status: 'skip', title: 'Training launch', message: 'Waiting for training launch diagnostics.' }]
+  }
+
+  return trainingLaunchDiagnostics.checks.map((check) => ({
+    status: check.status,
+    title: check.title,
+    message: check.message,
+    detail: check.detail,
+    suggestion: check.suggestion,
+    command: check.command,
+    outputTail: check.outputTail
+  }))
+}
+
+function getAcceleratorRows(acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null): MatrixRow[] {
+  if (!acceleratorDiagnostics) {
+    return [{ status: 'skip', title: 'Accelerator probe', message: 'Waiting for accelerator diagnostics.' }]
+  }
+
+  const summaryStatus: MatrixStatus = acceleratorDiagnostics.status === 'ready' || (acceleratorDiagnostics.status === 'cpu_only' && !acceleratorDiagnostics.hostNvidiaSmiAvailable)
+    ? 'pass'
+    : acceleratorDiagnostics.status === 'advisory' || acceleratorDiagnostics.status === 'cpu_only'
+    ? 'warn'
+    : acceleratorDiagnostics.status === 'not_checked'
+    ? 'skip'
+    : 'fail'
+
+  const rows: MatrixRow[] = [
+    {
+      status: summaryStatus,
+      title: getAcceleratorLabel(acceleratorDiagnostics.status),
+      message: acceleratorDiagnostics.headline,
+      detail: acceleratorDiagnostics.detail,
+      suggestion: acceleratorDiagnostics.suggestion
+    }
+  ]
+
+  if (acceleratorDiagnostics.torchImportOk != null) {
+    rows.push({
+      status: acceleratorDiagnostics.torchImportOk ? 'pass' : 'fail',
+      title: 'Torch import',
+      message: acceleratorDiagnostics.torchImportOk ? `Torch ${formatMaybeText(acceleratorDiagnostics.torchVersion, 'version not reported')}` : 'Torch could not import.',
+      detail: `CUDA build: ${formatMaybeText(acceleratorDiagnostics.torchCudaVersion, 'CPU-only or not reported')}; ROCm HIP: ${formatMaybeText(acceleratorDiagnostics.hipVersion, 'not reported')}`
+    })
+  }
+
+  if (acceleratorDiagnostics.cudaAvailable != null || acceleratorDiagnostics.mpsAvailable != null) {
+    rows.push({
+      status: acceleratorDiagnostics.cudaAvailable || acceleratorDiagnostics.mpsAvailable ? 'pass' : acceleratorDiagnostics.hostNvidiaSmiAvailable ? 'fail' : 'pass',
+      title: 'Hardware visibility',
+      message: acceleratorDiagnostics.cudaAvailable
+        ? `CUDA/ROCm visible: ${formatMaybeText(acceleratorDiagnostics.deviceName, 'device name not reported')}`
+        : acceleratorDiagnostics.mpsAvailable
+        ? 'Apple MPS is visible.'
+        : acceleratorDiagnostics.hostNvidiaSmiAvailable
+        ? 'Host NVIDIA GPU exists, but PyTorch cannot see CUDA.'
+        : 'No supported GPU visible; CPU training can still work.',
+      detail: `Device count: ${acceleratorDiagnostics.cudaDeviceCount != null ? String(acceleratorDiagnostics.cudaDeviceCount) : 'unknown'}`
+    })
+  }
+
+  if (acceleratorDiagnostics.lightningImportOk != null) {
+    rows.push({
+      status: acceleratorDiagnostics.lightningImportOk ? (acceleratorDiagnostics.lightningCudaAvailable === false && acceleratorDiagnostics.cudaAvailable ? 'warn' : 'pass') : 'warn',
+      title: 'Lightning',
+      message: acceleratorDiagnostics.lightningImportOk
+        ? `${formatMaybeText(acceleratorDiagnostics.lightningPackage, 'Lightning')} ${formatMaybeText(acceleratorDiagnostics.lightningVersion, 'version not reported')}`
+        : 'Lightning was not importable or not reported.',
+      detail: `Lightning CUDA available: ${formatMaybeBoolean(acceleratorDiagnostics.lightningCudaAvailable)}`
+    })
+  }
+
+  return rows
+}
+
+function getVersionRows(namVersionInfo: NamVersionInfo | null): MatrixRow[] {
+  if (!namVersionInfo) {
+    return [{ status: 'skip', title: 'NAM version', message: 'Waiting for version check.' }]
+  }
+
+  if (namVersionInfo.checkStatus !== 'ok') {
+    return [{ status: 'warn', title: 'NAM version', message: namVersionInfo.errorMessage ?? 'Version check could not complete.' }]
+  }
+
+  return [{
+    status: namVersionInfo.isUpToDate === false ? 'warn' : 'pass',
+    title: 'NAM version',
+    message: namVersionInfo.isUpToDate === false ? 'A newer NAM version is available.' : 'Installed NAM is up to date.',
+    detail: `Installed: ${namVersionInfo.installedVersion ?? 'not detected'}; Latest: ${namVersionInfo.latestVersion ?? 'not reported'}`
+  }]
+}
+
+function getSummaryTiles(
+  validation: BackendValidationSummary | null,
+  acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null,
+  trainingLaunchDiagnostics: TrainingLaunchDiagnosticsSummary | null,
+  namVersionInfo: NamVersionInfo | null
+): SummaryTile[] {
+  const acceleratorStatus: MatrixStatus = !acceleratorDiagnostics
+    ? 'skip'
+    : acceleratorDiagnostics.status === 'ready' || (acceleratorDiagnostics.status === 'cpu_only' && !acceleratorDiagnostics.hostNvidiaSmiAvailable)
+    ? 'pass'
+    : acceleratorDiagnostics.status === 'advisory' || acceleratorDiagnostics.status === 'cpu_only'
+    ? 'warn'
+    : acceleratorDiagnostics.status === 'not_checked'
+    ? 'skip'
+    : 'fail'
+
+  return [
+    {
+      title: 'Backend',
+      status: validation ? (validation.overallOk ? 'pass' : 'fail') : 'skip',
+      label: validation ? (validation.overallOk ? 'Ready' : 'Needs Fix') : 'Checking',
+      detail: validation ? (validation.overallOk ? 'Conda, Python, NAM, and nam-full are reachable.' : 'One or more backend checks failed.') : 'Waiting for backend validation.',
+      checkedAt: validation?.checkedAt ?? null
+    },
+    {
+      title: 'Accelerator',
+      status: acceleratorStatus,
+      label: acceleratorDiagnostics ? getAcceleratorLabelForIssue(acceleratorDiagnostics.issue).replace(/^✓ |^⚠ |^✗ /, '') : 'Checking',
+      detail: acceleratorDiagnostics?.headline ?? 'Waiting for accelerator diagnostics.',
+      checkedAt: acceleratorDiagnostics?.checkedAt ?? null
+    },
+    {
+      title: 'Training Launch',
+      status: trainingLaunchDiagnostics
+        ? trainingLaunchDiagnostics.status === 'ready'
+          ? 'pass'
+          : trainingLaunchDiagnostics.status === 'advisory'
+          ? 'warn'
+          : trainingLaunchDiagnostics.status === 'not_checked'
+          ? 'skip'
+          : 'fail'
+        : 'skip',
+      label: trainingLaunchDiagnostics ? (trainingLaunchDiagnostics.status === 'ready' ? 'Ready' : trainingLaunchDiagnostics.status === 'advisory' ? 'Check Setup' : 'Blocked') : 'Checking',
+      detail: trainingLaunchDiagnostics?.headline ?? 'Waiting for launch readiness diagnostics.',
+      checkedAt: trainingLaunchDiagnostics?.checkedAt ?? null
+    },
+    {
+      title: 'NAM Version',
+      status: !namVersionInfo ? 'skip' : namVersionInfo.checkStatus !== 'ok' || namVersionInfo.isUpToDate === false ? 'warn' : 'pass',
+      label: getVersionStatusBadge(namVersionInfo).label,
+      detail: namVersionInfo?.checkStatus === 'ok'
+        ? `Installed ${namVersionInfo.installedVersion ?? 'unknown'}; latest ${namVersionInfo.latestVersion ?? 'unknown'}.`
+        : namVersionInfo?.errorMessage ?? 'Waiting for version check.',
+      checkedAt: null
+    }
+  ]
+}
+
+function findFirstBackendFailure(validation: BackendValidationSummary | null): BackendCheckResult | null {
+  if (!validation || validation.overallOk) {
+    return null
+  }
+
+  return [
+    validation.condaReachable,
+    validation.environmentReachable,
+    validation.pythonReachable,
+    validation.namInstalled,
+    validation.namFullAvailable
+  ].find((result) => !result.ok && result.code !== 'unknown') ?? null
+}
+
+function buildBackendAction(settings: AppSettings | null, failure: BackendCheckResult): ActionItem {
+  const commands = getDiagnosticCommands(settings)
+  const condaLookupCommand = window.namBot.platform === 'win32' ? 'where conda' : 'which conda'
+
+  if (failure.code.includes('conda')) {
+    return {
+      title: 'Fix This First',
+      headline: 'Conda is not reachable',
+      body: 'NAM-BOT cannot train until it can launch Conda from the desktop app.',
+      steps: ['Open a terminal.', `Run ${condaLookupCommand}.`, 'Copy the full Conda executable path into Settings.', 'Return here and click Re-check All.'],
+      commands: [{ label: 'Find Conda', command: condaLookupCommand }],
+      verify: 'The Backend tile should change to Ready.',
+      tone: 'fail'
+    }
+  }
+
+  if (failure.code.includes('env')) {
+    return {
+      title: 'Fix This First',
+      headline: 'The selected Conda environment is not ready',
+      body: 'NAM-BOT needs the exact Conda environment name or prefix where NAM is installed.',
+      steps: ['Open Settings.', 'Confirm the Conda environment name or prefix.', 'Use the exact name shown by Conda, then re-check Diagnostics.'],
+      commands: [{ label: 'List Conda Environments', command: 'conda env list' }],
+      verify: 'The Environment and Python rows should pass.',
+      tone: 'fail'
+    }
+  }
+
+  return {
+    title: 'Fix This First',
+    headline: failure.title,
+    body: failure.message,
+    steps: ['Repair the selected environment.', 'Keep NAM, torch, and Lightning in the same environment.', 'Re-run Diagnostics after the command completes.'],
+    commands: failure.code.includes('nam') ? [{ label: 'Install or Repair NAM', command: commands.reinstallNam }] : [],
+    verify: failure.suggestion ?? 'The failed backend row should pass after repair.',
+    tone: 'fail'
+  }
+}
+
+function buildTrainingLaunchAction(settings: AppSettings | null, diagnostics: TrainingLaunchDiagnosticsSummary): ActionItem | null {
+  if (diagnostics.status === 'ready') {
+    return null
+  }
+
+  const condaLookupCommand = window.namBot.platform === 'win32' ? 'where conda' : 'which conda'
+  const failedCheck = diagnostics.checks.find((check) => check.status === 'fail')
+  const warningCheck = diagnostics.checks.find((check) => check.status === 'warn')
+  const primaryCheck = failedCheck ?? warningCheck
+
+  if (diagnostics.issue === 'workspace_unwritable') {
+    return {
+      title: 'Fix This First',
+      headline: 'Training workspace is not writable',
+      body: 'NAM-BOT must create a temporary workspace before it launches training.',
+      steps: ['Open Settings.', 'Set Default Workspace Root to a local folder you can write to.', 'Avoid iCloud, OneDrive, Dropbox, network drives, and external drives while troubleshooting.', 'Re-check Diagnostics.'],
+      commands: [],
+      verify: 'The Workspace write row should pass.',
+      tone: 'fail'
+    }
+  }
+
+  if (diagnostics.issue === 'pty_launch_failed') {
+    return {
+      title: 'Fix This First',
+      headline: 'Training process could not start',
+      body: 'NAM-BOT can see the environment, but the operating system would not launch the terminal process used by real training.',
+      steps: ['Use a full Conda executable path instead of relying on PATH.', 'On macOS, move NAM-BOT to /Applications and open it from there.', 'Make sure the app build matches your CPU architecture.', 'Re-check Diagnostics.'],
+      commands: settings && settings.condaExecutablePath && isBareCondaSetting(settings) ? [{ label: 'Find Conda', command: condaLookupCommand }] : [],
+      verify: 'The PTY Python launch row should pass.',
+      tone: 'fail'
+    }
+  }
+
+  if (diagnostics.issue === 'mac_app_on_dmg' || diagnostics.issue === 'mac_app_translocated') {
+    return {
+      title: 'Recommended Setup Fix',
+      headline: 'macOS app location may be fragile',
+      body: primaryCheck?.message ?? diagnostics.detail,
+      steps: ['Drag NAM-BOT into /Applications.', 'Right-click NAM-BOT and choose Open.', 'Run Diagnostics again from the installed app.'],
+      commands: [],
+      verify: 'The App location row should pass or disappear.',
+      tone: 'warn'
+    }
+  }
+
+  if (diagnostics.issue === 'bare_conda_path') {
+    return {
+      title: 'Recommended Setup Fix',
+      headline: 'Conda path relies on PATH',
+      body: 'Training launch currently works, but desktop apps can lose terminal PATH settings. A full Conda path is more reliable.',
+      steps: ['Open a terminal.', `Run ${condaLookupCommand}.`, 'Paste the full executable path into Settings.', 'Re-check Diagnostics.'],
+      commands: [{ label: 'Find Conda', command: condaLookupCommand }],
+      verify: 'The Conda path style row should pass or disappear.',
+      tone: 'warn'
+    }
+  }
+
+  return {
+    title: diagnostics.status === 'advisory' ? 'Recommended Setup Fix' : 'Fix This First',
+    headline: diagnostics.headline,
+    body: diagnostics.detail,
+    steps: [primaryCheck?.suggestion ?? diagnostics.suggestion ?? 'Review the failing launch row, apply the suggested fix, then re-check Diagnostics.'],
+    commands: primaryCheck?.command ? [{ label: primaryCheck.title, command: primaryCheck.command }] : [],
+    verify: 'The Training Launch tile should change to Ready.',
+    tone: diagnostics.status === 'advisory' ? 'warn' : 'fail'
+  }
+}
+
+function isBareCondaSetting(settings: AppSettings): boolean {
+  const condaPath = settings.condaExecutablePath ?? ''
+  return condaPath.length > 0 && !condaPath.includes('\\') && !condaPath.includes('/')
+}
+
+function buildAcceleratorAction(
+  settings: AppSettings | null,
+  acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null,
+  acceleratorGuidance: AcceleratorGuidance | null
+): ActionItem | null {
+  if (!acceleratorDiagnostics || !acceleratorGuidance) {
+    return null
+  }
+
+  if (acceleratorDiagnostics.status === 'ready') {
+    return null
+  }
+
+  if (acceleratorDiagnostics.status === 'cpu_only' && !acceleratorDiagnostics.hostNvidiaSmiAvailable) {
+    return null
+  }
+
+  const commands = [...(acceleratorGuidance.setupSteps ?? []), ...acceleratorGuidance.steps]
+  return {
+    title: acceleratorDiagnostics.status === 'advisory' ? 'Recommended Setup Fix' : 'Fix This First',
+    headline: acceleratorGuidance.title,
+    body: acceleratorGuidance.body,
+    steps: [acceleratorGuidance.note ?? acceleratorDiagnostics.suggestion ?? 'Run the suggested repair command, then re-check Diagnostics.'],
+    commands,
+    verify: `After repair, run: ${getDiagnosticCommands(settings).verifyTorch}`,
+    tone: acceleratorDiagnostics.status === 'advisory' || acceleratorDiagnostics.status === 'cpu_only' ? 'warn' : 'fail'
+  }
+}
+
+function buildVersionAction(settings: AppSettings | null, namVersionInfo: NamVersionInfo | null): ActionItem | null {
+  if (!namVersionInfo || namVersionInfo.checkStatus !== 'ok' || namVersionInfo.isUpToDate !== false) {
+    return null
+  }
+
+  return {
+    title: 'Recommended Update',
+    headline: 'A newer NAM version is available',
+    body: 'Updating NAM is not always required, but newer releases can include training fixes and compatibility improvements.',
+    steps: ['Run the upgrade command in your selected environment.', 'Return to Diagnostics.', 'Click Re-check All.'],
+    commands: getUpgradeCommands(settings),
+    verify: 'The NAM Version tile should report Up to date.',
+    tone: 'warn'
+  }
+}
+
+function buildActionItems(
+  settings: AppSettings | null,
+  validation: BackendValidationSummary | null,
+  acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null,
+  trainingLaunchDiagnostics: TrainingLaunchDiagnosticsSummary | null,
+  namVersionInfo: NamVersionInfo | null,
+  acceleratorGuidance: AcceleratorGuidance | null
+): ActionItem[] {
+  const backendFailure = findFirstBackendFailure(validation)
+  const actions: ActionItem[] = []
+  if (backendFailure) {
+    actions.push(buildBackendAction(settings, backendFailure))
+  }
+
+  if (trainingLaunchDiagnostics) {
+    const launchAction = buildTrainingLaunchAction(settings, trainingLaunchDiagnostics)
+    if (launchAction) {
+      actions.push(launchAction)
+    }
+  }
+
+  const acceleratorAction = buildAcceleratorAction(settings, acceleratorDiagnostics, acceleratorGuidance)
+  if (acceleratorAction) {
+    actions.push(acceleratorAction)
+  }
+
+  const versionAction = buildVersionAction(settings, namVersionInfo)
+  if (versionAction) {
+    actions.push(versionAction)
+  }
+
+  return actions
+}
+
+function isSetupReady(
+  validation: BackendValidationSummary | null,
+  acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null,
+  trainingLaunchDiagnostics: TrainingLaunchDiagnosticsSummary | null
+): boolean {
+  const acceleratorReady = acceleratorDiagnostics?.status === 'ready' || (acceleratorDiagnostics?.status === 'cpu_only' && !acceleratorDiagnostics.hostNvidiaSmiAvailable)
+  return validation?.overallOk === true && acceleratorReady && trainingLaunchDiagnostics?.status === 'ready'
+}
+
+function ActionCenter({ actions, allReady, onOpenSettings }: { actions: ActionItem[]; allReady: boolean; onOpenSettings: () => void }) {
+  if (actions.length === 0) {
+    if (!allReady) {
+      return (
+        <div className="panel" style={{ marginBottom: '16px' }}>
+          <p style={{ color: 'var(--text-steel)', fontFamily: 'var(--font-arcade)', fontSize: '24px', marginBottom: '4px' }}>Diagnostics Pending</p>
+          <p style={{ color: 'var(--text-steel)', fontSize: '13px', lineHeight: 1.5 }}>
+            NAM-BOT is still waiting for enough diagnostic data to make a setup recommendation.
+          </p>
+        </div>
+      )
+    }
+
+    return (
+      <div className="panel" style={{ marginBottom: '16px', borderColor: 'var(--neon-green)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '16px', alignItems: 'center' }}>
+          <div>
+            <p style={{ color: 'var(--neon-green)', fontFamily: 'var(--font-arcade)', fontSize: '28px', marginBottom: '4px' }}>Ready To Train</p>
+            <p style={{ color: 'var(--text-steel)', fontSize: '13px', lineHeight: 1.5 }}>
+              NAM-BOT can reach the environment, inspect accelerator support, and launch the training process path successfully.
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const primary = actions[0]
+  const color = getStatusColor(primary.tone)
+  return (
+    <div className="panel" style={{ marginBottom: '16px', borderColor: color }}>
+      <div style={{ display: 'grid', gap: '12px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: '16px', alignItems: 'flex-start' }}>
+          <div>
+            <p style={{ color, fontFamily: 'var(--font-arcade)', fontSize: '28px', marginBottom: '4px' }}>{primary.title}</p>
+            <p style={{ color: 'var(--text-ash)', fontSize: '18px', marginBottom: '6px' }}>{primary.headline}</p>
+            <p style={{ color: 'var(--text-steel)', fontSize: '13px', lineHeight: 1.55 }}>{primary.body}</p>
+          </div>
+          <button className="btn btn-sm btn-secondary" onClick={onOpenSettings}>Open Settings</button>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: '14px' }}>
+          <div style={{ border: '1px solid var(--border-dim)', padding: '12px', backgroundColor: 'rgba(9, 9, 11, 0.45)' }}>
+            <p style={{ color: 'var(--text-ash)', fontFamily: 'var(--font-arcade)', fontSize: '18px', marginBottom: '8px' }}>How To Fix</p>
+            <ol style={{ color: 'var(--text-steel)', paddingLeft: '18px', lineHeight: 1.55, fontSize: '13px' }}>
+              {primary.steps.map((step) => <li key={step}>{step}</li>)}
+            </ol>
+            <p style={{ color: 'var(--neon-cyan)', fontSize: '12px', lineHeight: 1.45, marginTop: '10px' }}>Verify: {primary.verify}</p>
+          </div>
+          <div style={{ display: 'grid', alignContent: 'start' }}>
+            {primary.commands.length > 0 ? (
+              primary.commands.slice(0, 2).map((command) => <CopyableCodeBlock key={command.label} label={command.label} command={command.command} />)
+            ) : (
+              <div style={{ border: '1px solid var(--border-dim)', padding: '12px', color: 'var(--text-steel)', fontSize: '13px', lineHeight: 1.45 }}>
+                No command is needed for this fix. Update the setting, folder, or app location, then re-check.
+              </div>
+            )}
+          </div>
+        </div>
+
+        {actions.length > 1 && (
+          <div style={{ borderTop: '1px solid var(--border-dim)', paddingTop: '10px' }}>
+            <p style={{ color: 'var(--text-steel)', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.12em', marginBottom: '6px' }}>Also detected</p>
+            <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+              {actions.slice(1).map((action) => (
+                <span key={action.headline} style={{ color: getStatusColor(action.tone), border: `1px solid ${getStatusColor(action.tone)}`, padding: '4px 8px', fontFamily: 'var(--font-arcade)', fontSize: '14px' }}>
+                  {action.headline}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export default function Diagnostics() {
+  const navigate = useNavigate()
   const {
     settings,
     validation,
     acceleratorDiagnostics,
+    trainingLaunchDiagnostics,
     namVersionInfo,
     isLoading,
     isAcceleratorDiagnosticsLoading,
+    isTrainingLaunchDiagnosticsLoading,
+    isNamVersionInfoLoading,
     loadSettings,
     validateBackend,
     loadAcceleratorDiagnostics,
+    loadTrainingLaunchDiagnostics,
     loadNamVersionInfo
   } = useAppStore()
 
-  const isChecking = isLoading || isAcceleratorDiagnosticsLoading
+  const isChecking = isLoading || isAcceleratorDiagnosticsLoading || isTrainingLaunchDiagnosticsLoading || isNamVersionInfoLoading
   const [showAiPrompt, setShowAiPrompt] = useState(false)
   const [showRawJson, setShowRawJson] = useState(false)
-  const [showAcceleratorExtended, setShowAcceleratorExtended] = useState(false)
-  const [showUpgradeSteps, setShowUpgradeSteps] = useState(false)
+  const [showAdvancedDetails, setShowAdvancedDetails] = useState(false)
   const acceleratorGuidance = getAcceleratorGuidance(acceleratorDiagnostics, settings)
-  const exportPanelCopy = getExportPanelCopy(validation, acceleratorDiagnostics)
-  const showTroubleshootingExport = shouldShowTroubleshootingExport(validation, acceleratorDiagnostics)
-  const diagnosticsJson = JSON.stringify(buildDiagnosticsExportPayload(settings, validation, acceleratorDiagnostics), null, 2)
-  const aiTroubleshootingPrompt = buildAiTroubleshootingPrompt(settings, validation, acceleratorDiagnostics)
+  const diagnosticsJson = JSON.stringify(buildDiagnosticsExportPayload(settings, validation, acceleratorDiagnostics, trainingLaunchDiagnostics), null, 2)
+  const aiTroubleshootingPrompt = buildAiTroubleshootingPrompt(settings, validation, acceleratorDiagnostics, trainingLaunchDiagnostics)
+  const tiles = getSummaryTiles(validation, acceleratorDiagnostics, trainingLaunchDiagnostics, namVersionInfo)
+  const actions = buildActionItems(settings, validation, acceleratorDiagnostics, trainingLaunchDiagnostics, namVersionInfo, acceleratorGuidance)
+  const matrixGroups: MatrixGroup[] = [
+    { title: 'Backend', rows: getBackendRows(validation) },
+    { title: 'Training Launch', rows: getTrainingLaunchRows(trainingLaunchDiagnostics) },
+    { title: 'Accelerator', rows: getAcceleratorRows(acceleratorDiagnostics) },
+    { title: 'NAM Version', rows: getVersionRows(namVersionInfo) }
+  ]
 
   useEffect(() => {
-    if (!settings) {
+    if (!settings && !isLoading) {
       void loadSettings()
     }
-    if (!validation) {
+    if (!validation && !isLoading) {
       void validateBackend()
     }
-    if (!acceleratorDiagnostics) {
+    if (!acceleratorDiagnostics && !isAcceleratorDiagnosticsLoading) {
       void loadAcceleratorDiagnostics()
     }
-    if (!namVersionInfo) {
+    if (!trainingLaunchDiagnostics && !isTrainingLaunchDiagnosticsLoading) {
+      void loadTrainingLaunchDiagnostics()
+    }
+    if (!namVersionInfo && !isNamVersionInfoLoading) {
       void loadNamVersionInfo()
     }
-  }, [acceleratorDiagnostics, loadAcceleratorDiagnostics, loadNamVersionInfo, loadSettings, namVersionInfo, settings, validation, validateBackend])
+  }, [
+    acceleratorDiagnostics,
+    isAcceleratorDiagnosticsLoading,
+    isLoading,
+    isNamVersionInfoLoading,
+    isTrainingLaunchDiagnosticsLoading,
+    loadAcceleratorDiagnostics,
+    loadNamVersionInfo,
+    loadSettings,
+    loadTrainingLaunchDiagnostics,
+    namVersionInfo,
+    settings,
+    trainingLaunchDiagnostics,
+    validation,
+    validateBackend
+  ])
 
   const handleRecheck = async () => {
-    await Promise.all([validateBackend(), loadAcceleratorDiagnostics()])
+    await Promise.all([validateBackend(), loadAcceleratorDiagnostics(), loadTrainingLaunchDiagnostics(), loadNamVersionInfo()])
   }
 
-  if (isChecking && !validation && !acceleratorDiagnostics) {
+  if (isChecking && !validation && !acceleratorDiagnostics && !trainingLaunchDiagnostics) {
     return (
       <div className="layout-main">
         <div className="panel">
-          <p className="processing-text" style={{ color: 'var(--text-steel)', textAlign: 'center', padding: '40px' }}>
-            Running backend and accelerator diagnostics
+          <p className="processing-text" style={{ color: 'var(--text-steel)', textAlign: 'center', padding: '32px' }}>
+            Running setup, accelerator, and launch diagnostics
           </p>
         </div>
       </div>
@@ -857,475 +1526,81 @@ export default function Diagnostics() {
   return (
     <div className="layout-main">
       <div className="panel" style={{ marginBottom: '16px' }}>
-        <div className="panel-header">
-          <h3>Backend Diagnostics</h3>
+        <div className="panel-header" style={{ marginBottom: '12px' }}>
+          <h3>Diagnostics</h3>
           <button className={`btn btn-sm btn-green ${isChecking ? 'processing-text' : ''}`} onClick={handleRecheck} disabled={isChecking}>
-            {isChecking ? 'Checking' : 'Re-check'}
+            {isChecking ? 'Checking' : 'Re-check All'}
+          </button>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '10px' }}>
+          {tiles.map((tile) => <SummaryTileCard key={tile.title} tile={tile} />)}
+        </div>
+      </div>
+
+      <ActionCenter actions={actions} allReady={isSetupReady(validation, acceleratorDiagnostics, trainingLaunchDiagnostics)} onOpenSettings={() => navigate('/settings')} />
+      <DiagnosticMatrix groups={matrixGroups} />
+
+      <div className="panel" style={{ marginBottom: '16px' }}>
+        <div className="panel-header" style={{ marginBottom: showAdvancedDetails ? '12px' : 0 }}>
+          <h3>Advanced Details</h3>
+          <button className={`btn btn-sm ${showAdvancedDetails ? 'btn-blue is-toggled' : 'btn-secondary'}`} onClick={() => setShowAdvancedDetails((value) => !value)}>
+            {showAdvancedDetails ? 'Hide Details' : 'Show Details'}
           </button>
         </div>
 
-        {validation ? (
-          <>
-            <div
-              style={{
-                padding: '20px',
-                marginBottom: '20px',
-                border: `2px solid ${validation.overallOk ? 'var(--neon-green)' : 'var(--neon-magenta)'}`,
-                backgroundColor: 'var(--bg-void)',
-                textAlign: 'center'
-              }}
-            >
-              <h2
-                style={{
-                  fontFamily: 'var(--font-arcade)',
-                  fontSize: '32px',
-                  color: validation.overallOk ? 'var(--neon-green)' : 'var(--neon-magenta)',
-                  marginBottom: '8px'
-                }}
-              >
-                {validation.overallOk ? '✓ BACKEND READY' : '✗ BACKEND NOT READY'}
-              </h2>
-              <p style={{ color: 'var(--text-steel)' }}>Last checked: {new Date(validation.checkedAt).toLocaleString()}</p>
+        {showAdvancedDetails && (
+          <div style={{ display: 'grid', gap: '16px' }}>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr', border: '1px solid var(--border-dim)' }}>
+              <DiagnosticFact label="Target environment" value={getEnvironmentReference(settings)} />
+              <DiagnosticFact label="Workspace root" value={formatMaybeText(trainingLaunchDiagnostics?.workspaceRoot, 'Not reported')} />
+              <DiagnosticFact label="App executable" value={formatMaybeText(trainingLaunchDiagnostics?.appExecutablePath, 'Not reported')} />
+              <DiagnosticFact label="Process arch" value={trainingLaunchDiagnostics?.processArch ?? 'Not reported'} />
+              <DiagnosticFact label="Python version" value={formatMaybeText(acceleratorDiagnostics?.pythonVersion, 'Not reported')} />
+              <DiagnosticFact label="Python executable" value={formatMaybeText(acceleratorDiagnostics?.pythonExecutable, 'Not reported')} />
+              <DiagnosticFact label="Python platform" value={formatMaybeText(acceleratorDiagnostics?.pythonPlatform, 'Not reported')} />
+              <DiagnosticFact label="Host NVIDIA" value={formatMaybeBoolean(acceleratorDiagnostics?.hostNvidiaSmiAvailable)} />
+              <DiagnosticFact label="Host GPU" value={formatMaybeText(acceleratorDiagnostics?.hostNvidiaGpuName, 'Not detected')} />
+              <DiagnosticFact label="NVIDIA driver" value={formatMaybeText(acceleratorDiagnostics?.hostDriverVersion, 'Not reported')} />
+              <DiagnosticFact label="Torch version" value={formatMaybeText(acceleratorDiagnostics?.torchVersion, 'Not reported')} />
+              <DiagnosticFact label="Torch CUDA build" value={formatMaybeText(acceleratorDiagnostics?.torchCudaVersion, 'CPU-only or not reported')} />
+              <DiagnosticFact label="ROCm HIP version" value={formatMaybeText(acceleratorDiagnostics?.hipVersion, 'Not reported')} />
+              <DiagnosticFact label="CUDA available" value={formatMaybeBoolean(acceleratorDiagnostics?.cudaAvailable)} />
+              <DiagnosticFact label="MPS available" value={formatMaybeBoolean(acceleratorDiagnostics?.mpsAvailable)} />
+              <DiagnosticFact label="NAM version" value={formatMaybeText(acceleratorDiagnostics?.namVersion, 'Not reported')} />
+              <DiagnosticFact label="Lightning package" value={formatMaybeText(acceleratorDiagnostics?.lightningPackage, 'Not installed or not importable')} />
+              <DiagnosticFact label="Lightning version" value={formatMaybeText(acceleratorDiagnostics?.lightningVersion, 'Not reported')} />
             </div>
 
-            <CheckResult result={validation.condaReachable} />
-            <CheckResult result={validation.environmentReachable} />
-            <CheckResult result={validation.pythonReachable} />
-            <CheckResult result={validation.namInstalled} />
-            <CheckResult result={validation.namFullAvailable} />
-          </>
-        ) : (
-          <div style={{ textAlign: 'center', padding: '40px' }}>
-            <p style={{ color: 'var(--text-steel)', marginBottom: '16px' }}>No validation results yet.</p>
-            <button className={`btn btn-primary ${isChecking ? 'processing-text' : ''}`} onClick={handleRecheck} disabled={isChecking}>
-              {isChecking ? 'Validating' : 'Run Validation'}
-            </button>
-          </div>
-        )}
-      </div>
-
-      <div className="panel" style={{ marginBottom: '16px' }}>
-        <div className="panel-header">
-          <h3>Accelerator Diagnostics</h3>
-          <button 
-            className="btn btn-sm btn-secondary" 
-            onClick={() => setShowAcceleratorExtended(!showAcceleratorExtended)}
-            style={{ minWidth: '100px' }}
-          >
-            {showAcceleratorExtended ? 'Hide Details' : 'Show Details'}
-          </button>
-        </div>
-
-        {acceleratorDiagnostics ? (
-          <>
-            <div
-              style={{
-                padding: '20px',
-                marginBottom: '20px',
-                border: `2px solid ${getAcceleratorAccent(acceleratorDiagnostics.status)}`,
-                backgroundColor: 'var(--bg-void)'
-              }}
-            >
-              <p
-                style={{
-                  color: getAcceleratorAccent(acceleratorDiagnostics.status),
-                  fontFamily: 'var(--font-arcade)',
-                  fontSize: '28px',
-                  marginBottom: '10px'
-                }}
-              >
-                {getAcceleratorLabelForIssue(acceleratorDiagnostics.issue)}
+            <div style={{ border: '1px solid var(--border-dim)', backgroundColor: 'rgba(9, 9, 11, 0.45)', padding: '14px' }}>
+              <p style={{ color: 'var(--text-ash)', fontFamily: 'var(--font-arcade)', fontSize: '18px', marginBottom: '8px' }}>Troubleshooting Export</p>
+              <p style={{ color: 'var(--text-steel)', fontSize: '13px', lineHeight: 1.5, marginBottom: '12px' }}>
+                These exports include backend checks, accelerator state, training launch readiness, host context, and prepared repair commands.
               </p>
-              <p style={{ color: 'var(--text-ash)', fontSize: '18px', marginBottom: '8px' }}>{acceleratorDiagnostics.headline}</p>
-              <p
-                style={{
-                  color: 'var(--text-steel)',
-                  fontSize: '14px',
-                  lineHeight: '1.6',
-                  marginBottom: acceleratorDiagnostics.suggestion ? '10px' : '8px'
-                }}
-              >
-                {acceleratorDiagnostics.detail}
-              </p>
-              {acceleratorDiagnostics.suggestion && (
-                <p style={{ color: 'var(--neon-cyan)', fontSize: '13px', lineHeight: '1.5' }}>→ {acceleratorDiagnostics.suggestion}</p>
-              )}
-              <p style={{ color: 'var(--text-steel)', fontSize: '12px', marginTop: '10px' }}>
-                Last checked: {new Date(acceleratorDiagnostics.checkedAt).toLocaleString()}
-              </p>
-            </div>
-            
-            {showAcceleratorExtended && (
-              <>
-                <div
-                  style={{
-                    display: 'grid',
-                    gridTemplateColumns: '1fr',
-                    border: '1px solid var(--border-dim)',
-                    marginBottom: acceleratorDiagnostics.errors.length > 0 || acceleratorGuidance ? '16px' : '0'
-                  }}
-                >
-                  <DiagnosticFact label="Probe issue" value={formatMaybeText(acceleratorDiagnostics.issue, 'Unknown')} />
-                  <DiagnosticFact label="Target environment" value={getEnvironmentReference(settings)} />
-                  <DiagnosticFact label="Python version" value={formatMaybeText(acceleratorDiagnostics.pythonVersion, 'Not reported')} />
-                  <DiagnosticFact label="Python executable" value={formatMaybeText(acceleratorDiagnostics.pythonExecutable, 'Not reported')} />
-                  <DiagnosticFact label="Python platform" value={formatMaybeText(acceleratorDiagnostics.pythonPlatform, 'Not reported')} />
-                  <DiagnosticFact label="Host NVIDIA" value={formatMaybeBoolean(acceleratorDiagnostics.hostNvidiaSmiAvailable)} />
-                  <DiagnosticFact label="Host GPU" value={formatMaybeText(acceleratorDiagnostics.hostNvidiaGpuName, 'Not detected')} />
-                  <DiagnosticFact label="NVIDIA driver" value={formatMaybeText(acceleratorDiagnostics.hostDriverVersion, 'Not reported')} />
-                  <DiagnosticFact label="Torch import" value={formatMaybeBoolean(acceleratorDiagnostics.torchImportOk)} />
-                  <DiagnosticFact label="Torch version" value={formatMaybeText(acceleratorDiagnostics.torchVersion, 'Not reported')} />
-                  <DiagnosticFact label="Torch CUDA build" value={formatMaybeText(acceleratorDiagnostics.torchCudaVersion, 'CPU-only or not reported')} />
-                  <DiagnosticFact label="ROCm HIP version" value={formatMaybeText(acceleratorDiagnostics.hipVersion, 'Not reported')} />
-                  <DiagnosticFact label="CUDA available" value={formatMaybeBoolean(acceleratorDiagnostics.cudaAvailable)} />
-                  <DiagnosticFact
-                    label="CUDA device count"
-                    value={acceleratorDiagnostics.cudaDeviceCount != null ? String(acceleratorDiagnostics.cudaDeviceCount) : 'Unknown'}
-                  />
-                  <DiagnosticFact label="Primary device" value={formatMaybeText(acceleratorDiagnostics.deviceName, 'No CUDA device detected')} />
-                  <DiagnosticFact label="NAM import" value={formatMaybeBoolean(acceleratorDiagnostics.namImportOk)} />
-                  <DiagnosticFact label="NAM version" value={formatMaybeText(acceleratorDiagnostics.namVersion, 'Not reported')} />
-                  <DiagnosticFact label="Lightning package" value={formatMaybeText(acceleratorDiagnostics.lightningPackage, 'Not installed or not importable')} />
-                  <DiagnosticFact label="Lightning version" value={formatMaybeText(acceleratorDiagnostics.lightningVersion, 'Not reported')} />
-                  <DiagnosticFact label="Lightning CUDA check" value={formatMaybeBoolean(acceleratorDiagnostics.lightningCudaAvailable)} />
-                  <DiagnosticFact label="MPS available" value={formatMaybeBoolean(acceleratorDiagnostics.mpsAvailable)} />
-                </div>
-
-                {acceleratorGuidance && (
-                  <div
-                    style={{
-                      border: '1px solid var(--border-dim)',
-                      backgroundColor: 'rgba(9, 9, 11, 0.45)',
-                      padding: '14px',
-                      marginBottom: '16px'
-                    }}
-                  >
-                    <p
-                      style={{
-                        color: 'var(--text-ash)',
-                        fontFamily: 'var(--font-arcade)',
-                        fontSize: '18px',
-                        marginBottom: '8px'
-                      }}
-                    >
-                      {acceleratorGuidance.title}
-                    </p>
-                    <p
-                      style={{
-                        color: 'var(--text-steel)',
-                        fontSize: '13px',
-                        lineHeight: '1.6',
-                        marginBottom: '12px'
-                      }}
-                    >
-                      {acceleratorGuidance.body}
-                    </p>
-                    {acceleratorGuidance.setupSteps?.map((step) => (
-                      <CopyableCodeBlock key={step.label} label={step.label} command={step.command} />
-                    ))}
-                    {acceleratorGuidance.steps.map((step) => (
-                      <CopyableCodeBlock key={step.label} label={step.label} command={step.command} />
-                    ))}
-                    {acceleratorGuidance.note && (
-                      <p style={{ color: 'var(--neon-cyan)', fontSize: '13px', lineHeight: '1.5' }}>→ {acceleratorGuidance.note}</p>
-                    )}
-                  </div>
-                )}
-
-                {showTroubleshootingExport && (
-                  <div
-                    style={{
-                      border: '1px solid var(--border-dim)',
-                      backgroundColor: 'rgba(9, 9, 11, 0.45)',
-                      padding: '14px',
-                      marginBottom: acceleratorDiagnostics.errors.length > 0 ? '16px' : '0'
-                    }}
-                  >
-                    <p
-                      style={{
-                        color: 'var(--text-ash)',
-                        fontFamily: 'var(--font-arcade)',
-                        fontSize: '18px',
-                        marginBottom: '8px'
-                      }}
-                    >
-                      {exportPanelCopy.title}
-                    </p>
-                    <p
-                      style={{
-                        color: 'var(--text-steel)',
-                        fontSize: '13px',
-                        lineHeight: '1.6',
-                        marginBottom: '12px'
-                      }}
-                    >
-                      {exportPanelCopy.body}
-                    </p>
-                    <div style={{ display: 'grid', gap: '12px', marginBottom: showAiPrompt || showRawJson ? '12px' : '10px' }}>
-                      <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
-                        <button className="btn btn-primary" onClick={() => copyText(aiTroubleshootingPrompt)}>
-                          Copy AI Troubleshooting Prompt
-                        </button>
-                        <button
-                          className={`btn ${showAiPrompt ? 'btn-blue is-toggled' : 'btn-secondary'}`}
-                          onClick={() => setShowAiPrompt((value) => !value)}
-                        >
-                          {showAiPrompt ? 'Hide AI Prompt' : 'Show AI Prompt'}
-                        </button>
-                      </div>
-                      <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
-                        <button className="btn btn-secondary" onClick={() => copyText(diagnosticsJson)}>
-                          Copy Raw Diagnostics JSON
-                        </button>
-                        <button
-                          className={`btn ${showRawJson ? 'btn-blue is-toggled' : 'btn-secondary'}`}
-                          onClick={() => setShowRawJson((value) => !value)}
-                        >
-                          {showRawJson ? 'Hide Raw JSON' : 'Show Raw JSON'}
-                        </button>
-                      </div>
-                    </div>
-                    {showAiPrompt && <CopyableCodeBlock label="AI Troubleshooting Prompt" command={aiTroubleshootingPrompt} />}
-                    {showRawJson && <CopyableCodeBlock label="Raw Diagnostics JSON" command={diagnosticsJson} />}
-                    <p style={{ color: 'var(--neon-cyan)', fontSize: '13px', lineHeight: '1.5' }}>
-                      → The AI prompt asks for root cause, exact commands, verification steps, and whether NAM should use GPU after the fix.
-                    </p>
-                  </div>
-                )}
-
-                {acceleratorDiagnostics.errors.length > 0 && (
-                  <div
-                    style={{
-                      border: '1px solid var(--border-dim)',
-                      backgroundColor: 'rgba(9, 9, 11, 0.45)',
-                      padding: '14px'
-                    }}
-                  >
-                    <p
-                      style={{
-                        color: 'var(--text-ash)',
-                        fontFamily: 'var(--font-arcade)',
-                        fontSize: '18px',
-                        marginBottom: '10px'
-                      }}
-                    >
-                      Probe Notes
-                    </p>
-                    {acceleratorDiagnostics.errors.map((entry) => (
-                      <p
-                        key={entry}
-                        style={{
-                          color: 'var(--text-steel)',
-                          fontSize: '13px',
-                          lineHeight: '1.5',
-                          marginBottom: '8px'
-                        }}
-                      >
-                        {entry}
-                      </p>
-                    ))}
-                  </div>
-                )}
-              </>
-            )}
-          </>
-        ) : (
-          <div style={{ textAlign: 'center', padding: '32px' }}>
-            <p style={{ color: 'var(--text-steel)' }}>No accelerator diagnostics yet.</p>
-          </div>
-        )}
-      </div>
-
-      {!validation?.overallOk && (
-        <div className="panel">
-          <div className="panel-header">
-            <h3>Next Steps</h3>
-          </div>
-          <ol style={{ color: 'var(--text-steel)', paddingLeft: '20px', lineHeight: '1.8' }}>
-            <li>Go to Settings and configure your Conda executable path</li>
-            <li>Use <strong>conda</strong> on PATH or set a full Conda path in Settings</li>
-            <li>Set your Conda environment name or prefix. The default environment name is <strong>nam</strong></li>
-            <li>Click "Re-check" to verify everything is working</li>
-          </ol>
-        </div>
-      )}
-
-      <div className="panel" style={{ marginBottom: '16px' }}>
-        <div className="panel-header">
-          <h3>NAM Version Check</h3>
-        </div>
-
-        {namVersionInfo ? (
-          <>
-            <div
-              style={{
-                padding: '20px',
-                marginBottom: '20px',
-                border: `2px solid ${
-                  namVersionInfo.checkStatus === 'ok' && namVersionInfo.isUpToDate
-                    ? 'var(--neon-green)'
-                    : namVersionInfo.checkStatus === 'ok' && namVersionInfo.isUpToDate === false
-                    ? 'var(--neon-cyan)'
-                    : 'var(--border-dim)'
-                }`,
-                backgroundColor: 'var(--bg-void)'
-              }}
-            >
-              <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '16px' }}>
-                <span
-                  style={{
-                    color: getVersionStatusBadge(namVersionInfo).color,
-                    fontSize: '28px',
-                    fontFamily: 'var(--font-arcade)'
-                  }}
-                >
-                  {getVersionStatusBadge(namVersionInfo).icon} {getVersionStatusBadge(namVersionInfo).label}
-                </span>
+              <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', marginBottom: showAiPrompt || showRawJson ? '12px' : 0 }}>
+                <button className="btn btn-primary" onClick={() => copyText(aiTroubleshootingPrompt)}>Copy AI Prompt</button>
+                <button className={`btn ${showAiPrompt ? 'btn-blue is-toggled' : 'btn-secondary'}`} onClick={() => setShowAiPrompt((value) => !value)}>
+                  {showAiPrompt ? 'Hide AI Prompt' : 'Show AI Prompt'}
+                </button>
+                <button className="btn btn-secondary" onClick={() => copyText(diagnosticsJson)}>Copy Raw JSON</button>
+                <button className={`btn ${showRawJson ? 'btn-blue is-toggled' : 'btn-secondary'}`} onClick={() => setShowRawJson((value) => !value)}>
+                  {showRawJson ? 'Hide Raw JSON' : 'Show Raw JSON'}
+                </button>
               </div>
-
-              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px', marginBottom: '16px' }}>
-                <div>
-                  <p style={{ color: 'var(--text-steel)', fontSize: '11px', textTransform: 'uppercase', marginBottom: '4px' }}>
-                    Installed Version
-                  </p>
-                  <p style={{ color: 'var(--text-ash)', fontSize: '16px', fontFamily: 'Consolas, Monaco, monospace' }}>
-                    {namVersionInfo.installedVersion ?? 'Not detected'}
-                  </p>
-                </div>
-                <div>
-                  <p style={{ color: 'var(--text-steel)', fontSize: '11px', textTransform: 'uppercase', marginBottom: '4px' }}>
-                    Latest Version
-                  </p>
-                  <p style={{ color: 'var(--text-ash)', fontSize: '16px', fontFamily: 'Consolas, Monaco, monospace' }}>
-                    {namVersionInfo.latestVersion ?? 'Unable to check'}
-                  </p>
-                </div>
-              </div>
-
-              {namVersionInfo.isUpToDate === false && namVersionInfo.latestReleaseUrl && (
-                <div style={{ marginBottom: '16px' }}>
-                  <p style={{ color: 'var(--neon-cyan)', fontSize: '13px', marginBottom: '8px' }}>
-                    → A newer version is available. Upgrading is recommended to access the latest features, bug fixes, and training improvements.
-                  </p>
-                  {namVersionInfo.publishedAt && (
-                    <p style={{ color: 'var(--text-steel)', fontSize: '12px' }}>
-                      Latest release published: {new Date(namVersionInfo.publishedAt).toLocaleDateString()}
-                    </p>
-                  )}
-                </div>
-              )}
-
-              {namVersionInfo.checkStatus !== 'ok' && namVersionInfo.errorMessage && (
-                <div style={{ marginBottom: '16px' }}>
-                  <p style={{ color: 'var(--neon-magenta)', fontSize: '13px', marginBottom: '8px' }}>
-                    → {namVersionInfo.errorMessage}
-                  </p>
-                  {namVersionInfo.checkStatus === 'offline' && (
-                    <p style={{ color: 'var(--text-steel)', fontSize: '12px' }}>
-                      Check your internet connection and try again.
-                    </p>
-                  )}
-                  {namVersionInfo.checkStatus === 'rate_limited' && (
-                    <p style={{ color: 'var(--text-steel)', fontSize: '12px' }}>
-                      GitHub API rate limit exceeded. Please try again later.
-                    </p>
-                  )}
-                </div>
-              )}
-
-              {namVersionInfo.isUpToDate === false && (
-                <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap', alignItems: 'center' }}>
-                  <button
-                    className={`btn ${showUpgradeSteps ? 'btn-blue is-toggled' : 'btn-secondary'}`}
-                    onClick={() => setShowUpgradeSteps(!showUpgradeSteps)}
-                  >
-                    {showUpgradeSteps ? 'Hide Upgrade Steps' : 'View Upgrade Steps'}
-                  </button>
-                  <button
-                    className="btn btn-secondary"
-                    onClick={() => {
-                      const commands = getUpgradeCommands(settings)
-                      const upgradeCommand = commands.find((cmd) => cmd.label === 'Upgrade NAM')
-                      if (upgradeCommand) {
-                        copyText(upgradeCommand.command)
-                      }
-                    }}
-                  >
-                    Copy Upgrade Command
-                  </button>
-                  {namVersionInfo.latestReleaseUrl && (
-                    <a
-                      href={namVersionInfo.latestReleaseUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="btn btn-secondary"
-                      style={{ textDecoration: 'none' }}
-                    >
-                      View Release Notes
-                    </a>
-                  )}
-                </div>
-              )}
+              {showAiPrompt && <CopyableCodeBlock label="AI Troubleshooting Prompt" command={aiTroubleshootingPrompt} />}
+              {showRawJson && <CopyableCodeBlock label="Raw Diagnostics JSON" command={diagnosticsJson} />}
             </div>
 
-            {showUpgradeSteps && namVersionInfo.isUpToDate === false && (
-              <div
-                style={{
-                  border: '1px solid var(--border-dim)',
-                  backgroundColor: 'rgba(9, 9, 11, 0.45)',
-                  padding: '14px',
-                  marginBottom: '16px'
-                }}
-              >
-                <p
-                  style={{
-                    color: 'var(--text-ash)',
-                    fontFamily: 'var(--font-arcade)',
-                    fontSize: '18px',
-                    marginBottom: '12px'
-                  }}
-                >
-                  Manual Upgrade Steps
-                </p>
-                <p
-                  style={{
-                    color: 'var(--text-steel)',
-                    fontSize: '13px',
-                    lineHeight: '1.6',
-                    marginBottom: '16px'
-                  }}
-                >
-                  Run these commands in your terminal to upgrade NAM to the latest version:
-                </p>
-                {getUpgradeCommands(settings).map((step) => (
-                  <CopyableCodeBlock key={step.label} label={step.label} command={step.command} />
+            {(acceleratorDiagnostics?.errors.length ?? 0) > 0 && (
+              <div style={{ border: '1px solid var(--border-dim)', backgroundColor: 'rgba(9, 9, 11, 0.45)', padding: '14px' }}>
+                <p style={{ color: 'var(--text-ash)', fontFamily: 'var(--font-arcade)', fontSize: '18px', marginBottom: '8px' }}>Probe Notes</p>
+                {acceleratorDiagnostics?.errors.map((entry) => (
+                  <p key={entry} style={{ color: 'var(--text-steel)', fontSize: '13px', lineHeight: 1.45, marginBottom: '8px' }}>{entry}</p>
                 ))}
-                <p style={{ color: 'var(--neon-cyan)', fontSize: '13px', lineHeight: '1.5' }}>
-                  → After upgrading, return to this screen and click "Re-check" to verify the new version.
-                </p>
               </div>
             )}
-          </>
-        ) : (
-          <div style={{ textAlign: 'center', padding: '32px' }}>
-            <p style={{ color: 'var(--text-steel)' }}>Loading version information...</p>
           </div>
         )}
       </div>
-
-      {!validation?.overallOk && (
-        <div className="panel">
-          <div className="panel-header">
-            <h3>Next Steps</h3>
-          </div>
-          <ol style={{ color: 'var(--text-steel)', paddingLeft: '20px', lineHeight: '1.8' }}>
-            <li>Go to Settings and configure your Conda executable path</li>
-            <li>Use <strong>conda</strong> on PATH or set a full Conda path in Settings</li>
-            <li>Set your Conda environment name or prefix. The default environment name is <strong>nam</strong></li>
-            <li>Click "Re-check" to verify everything is working</li>
-          </ol>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/renderer/state/store.ts
+++ b/src/renderer/state/store.ts
@@ -132,6 +132,59 @@ export interface AcceleratorDiagnosticsSummary {
   errors: string[]
 }
 
+export type TrainingLaunchDiagnosticsStatus =
+  | 'ready'
+  | 'advisory'
+  | 'not_checked'
+  | 'error'
+
+export type TrainingLaunchDiagnosticsIssue =
+  | 'ready'
+  | 'not_checked'
+  | 'conda_not_configured'
+  | 'conda_unreachable'
+  | 'environment_not_configured'
+  | 'direct_python_unsupported'
+  | 'lightning_security_check_failed'
+  | 'lightning_vulnerable'
+  | 'workspace_unwritable'
+  | 'pty_launch_failed'
+  | 'pty_launch_timeout'
+  | 'pty_payload_missing'
+  | 'nam_full_pty_failed'
+  | 'nam_full_pty_timeout'
+  | 'mac_app_on_dmg'
+  | 'mac_app_translocated'
+  | 'bare_conda_path'
+
+export type TrainingLaunchCheckStatus = 'pass' | 'warn' | 'fail' | 'skip'
+
+export interface TrainingLaunchCheckResult {
+  status: TrainingLaunchCheckStatus
+  code: string
+  title: string
+  message: string
+  detail?: string
+  suggestion?: string
+  command?: string
+  outputTail?: string
+}
+
+export interface TrainingLaunchDiagnosticsSummary {
+  checkedAt: string
+  status: TrainingLaunchDiagnosticsStatus
+  issue: TrainingLaunchDiagnosticsIssue
+  headline: string
+  detail: string
+  suggestion?: string
+  workspaceRoot: string | null
+  workspacePath: string | null
+  appExecutablePath: string | null
+  processArch: string
+  checks: TrainingLaunchCheckResult[]
+  errors: string[]
+}
+
 export interface CondaDiscoverySummary {
   checkedAt: string
   isOnPath: boolean
@@ -178,6 +231,7 @@ interface AppState {
   settings: AppSettings | null
   validation: BackendValidationSummary | null
   acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null
+  trainingLaunchDiagnostics: TrainingLaunchDiagnosticsSummary | null
   condaDiscovery: CondaDiscoverySummary | null
   namVersionInfo: NamVersionInfo | null
   updateStatus: UpdateStatus
@@ -186,6 +240,8 @@ interface AppState {
   jobEditorSession: JobEditorSession | null
   isLoading: boolean;
   isAcceleratorDiagnosticsLoading: boolean;
+  isTrainingLaunchDiagnosticsLoading: boolean;
+  isNamVersionInfoLoading: boolean;
   isTraining: boolean;
   drafts: JobSpec[];
   queue: JobRuntimeState[];
@@ -193,6 +249,7 @@ interface AppState {
   setSettings: (settings: AppSettings) => void
   setValidation: (validation: BackendValidationSummary) => void
   setAcceleratorDiagnostics: (diagnostics: AcceleratorDiagnosticsSummary) => void
+  setTrainingLaunchDiagnostics: (diagnostics: TrainingLaunchDiagnosticsSummary) => void
   setCondaDiscovery: (condaDiscovery: CondaDiscoverySummary) => void
   setNamVersionInfo: (namVersionInfo: NamVersionInfo | null) => void
   setUpdateStatus: (updateStatus: UpdateStatus) => void
@@ -203,6 +260,7 @@ interface AppState {
   clearJobEditorSession: () => void
   setLoading: (loading: boolean) => void
   setAcceleratorDiagnosticsLoading: (loading: boolean) => void
+  setTrainingLaunchDiagnosticsLoading: (loading: boolean) => void
   setIsTraining: (isTraining: boolean) => void
   setDrafts: (drafts: JobSpec[] | ((prev: JobSpec[]) => JobSpec[])) => void
   setQueue: (queue: JobRuntimeState[] | ((prev: JobRuntimeState[]) => JobRuntimeState[])) => void
@@ -211,6 +269,7 @@ interface AppState {
   saveSettings: (settings: AppSettings) => Promise<void>
   validateBackend: () => Promise<void>
   loadAcceleratorDiagnostics: () => Promise<void>
+  loadTrainingLaunchDiagnostics: () => Promise<void>
   loadNamVersionInfo: () => Promise<void>
   detectConda: () => Promise<void>
   loadUpdateStatus: () => Promise<void>
@@ -223,6 +282,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   settings: null,
   validation: null,
   acceleratorDiagnostics: null,
+  trainingLaunchDiagnostics: null,
   condaDiscovery: null,
   namVersionInfo: null,
   updateStatus: createDefaultUpdateStatus('0.0.0'),
@@ -231,6 +291,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   jobEditorSession: null,
   isLoading: false,
   isAcceleratorDiagnosticsLoading: false,
+  isTrainingLaunchDiagnosticsLoading: false,
+  isNamVersionInfoLoading: false,
   isTraining: false,
   drafts: [],
   queue: [],
@@ -238,6 +300,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   setSettings: (settings) => set({ settings }),
   setValidation: (validation) => set({ validation }),
   setAcceleratorDiagnostics: (acceleratorDiagnostics) => set({ acceleratorDiagnostics }),
+  setTrainingLaunchDiagnostics: (trainingLaunchDiagnostics) => set({ trainingLaunchDiagnostics }),
   setCondaDiscovery: (condaDiscovery) => set({ condaDiscovery }),
   setNamVersionInfo: (namVersionInfo) => set({ namVersionInfo }),
   setUpdateStatus: (updateStatus) => set({ updateStatus }),
@@ -248,6 +311,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   clearJobEditorSession: () => set({ jobEditorSession: null }),
   setLoading: (isLoading) => set({ isLoading }),
   setAcceleratorDiagnosticsLoading: (isAcceleratorDiagnosticsLoading) => set({ isAcceleratorDiagnosticsLoading }),
+  setTrainingLaunchDiagnosticsLoading: (isTrainingLaunchDiagnosticsLoading) => set({ isTrainingLaunchDiagnosticsLoading }),
   setIsTraining: (isTraining) => set({ isTraining }),
   setDrafts: (drafts) => set((state) => ({ 
     drafts: typeof drafts === 'function' ? drafts(state.drafts) : drafts 
@@ -281,7 +345,10 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
   
   validateBackend: async () => {
-    set({ isLoading: true, validation: null })
+    if (get().isLoading) {
+      return
+    }
+    set({ isLoading: true })
     try {
       const validation = await window.namBot.settings.validate() as BackendValidationSummary
       set({ validation })
@@ -293,7 +360,10 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   loadAcceleratorDiagnostics: async () => {
-    set({ isAcceleratorDiagnosticsLoading: true, acceleratorDiagnostics: null })
+    if (get().isAcceleratorDiagnosticsLoading) {
+      return
+    }
+    set({ isAcceleratorDiagnosticsLoading: true })
     try {
       const acceleratorDiagnostics =
         await window.namBot.settings.getAcceleratorDiagnostics() as AcceleratorDiagnosticsSummary
@@ -305,13 +375,35 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
+  loadTrainingLaunchDiagnostics: async () => {
+    if (get().isTrainingLaunchDiagnosticsLoading) {
+      return
+    }
+    set({ isTrainingLaunchDiagnosticsLoading: true })
+    try {
+      const trainingLaunchDiagnostics =
+        await window.namBot.settings.getTrainingLaunchDiagnostics() as TrainingLaunchDiagnosticsSummary
+      set({ trainingLaunchDiagnostics })
+    } catch (error) {
+      console.error('Failed to load training launch diagnostics:', error)
+    } finally {
+      set({ isTrainingLaunchDiagnosticsLoading: false })
+    }
+  },
+
   loadNamVersionInfo: async () => {
+    if (get().isNamVersionInfoLoading) {
+      return
+    }
+    set({ isNamVersionInfoLoading: true })
     try {
       const namVersionInfo = await window.namBot.settings.getNamVersionInfo() as NamVersionInfo
       set({ namVersionInfo })
     } catch (error) {
       console.error('Failed to load NAM version info:', error)
       set({ namVersionInfo: null })
+    } finally {
+      set({ isNamVersionInfoLoading: false })
     }
   },
 


### PR DESCRIPTION
## Summary
- Add Training Launch diagnostics that verify workspace writability and the PTY-based `nam-full` launch path used by real jobs.
- Rework Diagnostics into compact readiness tiles, a prioritized action center, a check matrix, and one advanced details area.
- Prepare `0.5.1-rc.2` release metadata and update diagnostics documentation.

## Verification
- `npm run build`
- Started `npm run dev` in a visible terminal and confirmed diagnostics settle without repeated overlapping PTY probes.