### PR TITLE
Use A2 Full ESR for validation metadata

### DIFF
--- a/src/main/jobs/queueManager.ts
+++ b/src/main/jobs/queueManager.ts
@@ -209,9 +209,16 @@ function deriveTrainedEpochs(runtime: JobRuntimeState): number | null {
 
 function readConfirmedTrainingMetadata(runtime: JobRuntimeState): ConfirmedNamTrainingMetadata {
   const trainingMetadata: ConfirmedNamTrainingMetadata = {}
-  const bestValidationEsr = runtime.checkpointSummary?.bestValidationEsr
-  if (bestValidationEsr != null) {
-    trainingMetadata.validationEsr = bestValidationEsr
+  const checkpointSummary = runtime.checkpointSummary
+  const validationEsr =
+    checkpointSummary?.bestValidationEsrKind === 'aggregate'
+      ? checkpointSummary.packedSubmodels?.find(
+          (submodel) => submodel.submodelName === 'channels_8'
+        )?.bestValidationMetric
+      : checkpointSummary?.bestValidationEsr
+
+  if (validationEsr != null) {
+    trainingMetadata.validationEsr = validationEsr
   }
 
   const dataConfigPath = runtime.generatedConfigPaths?.dataConfig


### PR DESCRIPTION
## Summary

Writes the A2-Full ESR value as validation_esr in the .nam file instead of the Aggregate ESR.