### PR TITLE
fix: harden training workflows and prepare 0.6.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,33 @@ on:
   pull_request:
 
 jobs:
+  quality:
+    name: Typecheck and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck application and tests
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
   build-windows:
     name: Build Windows App
     runs-on: windows-2022
+    needs: quality
 
     steps:
       - name: Check out repository
@@ -28,6 +52,7 @@ jobs:
   build-macos:
     name: Build macOS App
     runs-on: macos-14
+    needs: quality
 
     steps:
       - name: Check out repository

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -16,7 +16,8 @@ jobs:
     name: Prepare Preview Metadata
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.meta.outputs.version }}
+      base_version: ${{ steps.meta.outputs.base_version }}
+      version: ${{ steps.meta.outputs.preview_version }}
       short_sha: ${{ steps.meta.outputs.short_sha }}
       preview_tag: ${{ steps.meta.outputs.preview_tag }}
 
@@ -24,16 +25,14 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
       - name: Compute preview identifiers
         id: meta
-        shell: bash
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          SHORT_SHA="${GITHUB_SHA::7}"
-          PREVIEW_TAG="preview-main-${SHORT_SHA}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
-          echo "preview_tag=$PREVIEW_TAG" >> "$GITHUB_OUTPUT"
+        run: node build/release-metadata.cjs preview
 
   quality:
     name: Typecheck and Test Preview
@@ -79,6 +78,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Stamp unique preview version
+        run: npm version "${{ needs.prepare.outputs.version }}" --no-git-tag-version --allow-same-version
+
       - name: Build production app
         run: npm run build
 
@@ -89,8 +91,7 @@ jobs:
         shell: powershell
         run: |
           $previewVersion = '${{ needs.prepare.outputs.version }}'
-          $shortSha = '${{ needs.prepare.outputs.short_sha }}'
-          $portableAsset = "release\NAM-BOT-Portable-$previewVersion-preview-$shortSha-Win64.zip"
+          $portableAsset = "release\NAM-BOT-Portable-$previewVersion-Win64.zip"
           Compress-Archive -Path 'release\win-unpacked\*' -DestinationPath $portableAsset -Force
 
       - name: Upload Windows preview artifacts
@@ -121,6 +122,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Stamp unique preview version
+        run: npm version "${{ needs.prepare.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Build production app
         run: npm run build

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   PREVIEW_RETENTION_COUNT: 10
@@ -35,10 +35,36 @@ jobs:
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
           echo "preview_tag=$PREVIEW_TAG" >> "$GITHUB_OUTPUT"
 
+  quality:
+    name: Typecheck and Test Preview
+    runs-on: ubuntu-latest
+    needs: prepare
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck application and tests
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
   build-windows:
     name: Build Windows Preview
     runs-on: windows-2022
-    needs: prepare
+    needs:
+      - prepare
+      - quality
 
     steps:
       - name: Check out repository
@@ -79,7 +105,9 @@ jobs:
   build-macos:
     name: Build macOS Preview
     runs-on: macos-14
-    needs: prepare
+    needs:
+      - prepare
+      - quality
 
     steps:
       - name: Check out repository
@@ -119,6 +147,8 @@ jobs:
       - prepare
       - build-windows
       - build-macos
+    permissions:
+      contents: write
 
     steps:
       - name: Check out repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
   quality:
     name: Typecheck and Test Release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release_metadata.outputs.version }}
+      release_tag: ${{ steps.release_metadata.outputs.release_tag }}
+      prerelease: ${{ steps.release_metadata.outputs.prerelease }}
 
     steps:
       - name: Check out repository
@@ -33,6 +37,10 @@ jobs:
         with:
           node-version: 22
           cache: npm
+
+      - name: Validate release tag, package version, and changelog
+        id: release_metadata
+        run: node build/release-metadata.cjs release
 
       - name: Install dependencies
         run: npm ci
@@ -72,7 +80,7 @@ jobs:
       - name: Compress portable app
         shell: powershell
         run: |
-          $releaseVersion = $env:RELEASE_TAG.TrimStart('v')
+          $releaseVersion = '${{ needs.quality.outputs.version }}'
           $portableAsset = "release\\NAM-BOT-Portable-$releaseVersion-Win64.zip"
           Compress-Archive -Path 'release\win-unpacked\*' -DestinationPath $portableAsset -Force
 
@@ -127,6 +135,7 @@ jobs:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
     needs:
+      - quality
       - release-windows
       - release-macos
     permissions:
@@ -189,18 +198,28 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_NOTES_FILE: ${{ runner.temp }}/release-notes.md
+          RELEASE_IS_PRERELEASE: ${{ needs.quality.outputs.prerelease }}
         shell: bash
         run: |
+          if [ "$RELEASE_IS_PRERELEASE" = "true" ]; then
+            RELEASE_FLAGS=(--prerelease --latest=false)
+          else
+            RELEASE_FLAGS=(--prerelease=false --latest)
+          fi
+
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release edit "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "$RELEASE_TAG" \
-              --notes-file "$RELEASE_NOTES_FILE"
+              --notes-file "$RELEASE_NOTES_FILE" \
+              "${RELEASE_FLAGS[@]}"
           else
             gh release create "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --title "$RELEASE_TAG" \
-              --notes-file "$RELEASE_NOTES_FILE"
+              --notes-file "$RELEASE_NOTES_FILE" \
+              --verify-tag \
+              "${RELEASE_FLAGS[@]}"
           fi
 
       - name: Upload Windows assets to GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,41 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
 
 jobs:
+  quality:
+    name: Typecheck and Test Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck application and tests
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
   release-windows:
     name: Package Windows Release
     runs-on: windows-2022
+    needs: quality
 
     steps:
       - name: Check out repository
@@ -62,6 +88,7 @@ jobs:
   release-macos:
     name: Package macOS Release
     runs-on: macos-14
+    needs: quality
 
     steps:
       - name: Check out repository
@@ -102,6 +129,8 @@ jobs:
     needs:
       - release-windows
       - release-macos
+    permissions:
+      contents: write
 
     steps:
       - name: Check out repository

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ Thumbs.db
 
 # Logs
 *.log
-logs/
+/logs/
 
 # Environment
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md - NAM-BOT Development Guide (v0.6.3)
+# AGENTS.md - NAM-BOT Development Guide (v0.6.4)
 
 This document provides guidance for AI agents working on the NAM-BOT project.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md - NAM-BOT Development Guide (v0.6.2)
+# AGENTS.md - NAM-BOT Development Guide (v0.6.3)
 
 This document provides guidance for AI agents working on the NAM-BOT project.
 
@@ -237,11 +237,17 @@ export const useAppStore = create<AppState>((set) => ({
 
 ## 7. Testing
 
-No test framework currently. To add:
+NAM-BOT uses Vitest for unit and integration-style tests.
 
 ```bash
-npm install -D vitest @testing-library/react jsdom
-npx vitest
+# Run the complete Vitest suite once
+npm test
+
+# Type-check main, preload, renderer, shared code, and test files
+npm run typecheck
+
+# Run type-checking, tests, and the production build in sequence
+npm run check
 ```
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-07-13
+
+### Added
+
+- Added atomic JSON persistence with recoverable backups, transactional draft-to-queue recovery, and regression coverage for persistence and preset path safety.
+
 ### Changed
 
 - Failed and stopped training cards now prioritize `Create Draft` so users can edit settings before queueing another run.
+- Settings now expose explicit dirty, saving, saved, and error states, flush pending changes during navigation, and validate the exact saved settings snapshot.
+- CI, preview, and release builds now require TypeScript checks and the Vitest suite before platform packaging, with least-privilege workflow permissions.
+- Electron now uses renderer sandboxing, exact production navigation checks, denied permission requests, and an HTTPS host allowlist for external links.
 
 ### Fixed
 
 - Auto-align preflight feedback now appears in the same terminal log as training, and expanded job details show the latency mode and actual delay used for the run.
+- Training jobs now claim only artifacts created or changed during their own run, and failed, canceled, or zero-exit runs without a new model can no longer publish an older or partial model as successful.
+- Workspace setup failures now terminate cleanly, and Stop, Force Stop, and shutdown cancel latency analysis and other preparation subprocesses as well as active training.
+- Each training run now uses one immutable backend-settings snapshot from validation through process launch.
+- Queue and batch persistence failures no longer delete the only durable draft copy; batch draft creation is atomic, idempotent, and guarded against duplicate submissions.
+- User preset IDs can no longer traverse outside the preset directory.
+- Diagnostic failures no longer trigger unbounded automatic IPC retries, and stale results are discarded after settings changes.
+- TypeScript project boundaries and previously hidden source errors are fixed so production and test code are checked consistently.
 
 ## [0.6.2] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-07-17
+
+### Changed
+
+- Updated vulnerable npm dependencies and refreshed the lockfile so the full dependency audit is clean.
+- Terminal logs now load incrementally with bounded renderer history, while high-volume training progress updates and queue persistence are coalesced to reduce UI lag.
+- Removed unsupported Direct Python configuration and unused queue-retention, log-retention, and launch-mode settings; older settings files migrate to supported Conda defaults.
+- Stable releases now require matching tag, package, and changelog versions, and preview packages receive unique Semantic Versions and artifact names.
+
+### Fixed
+
+- Force Stop now always moves a job to a terminal state, including a clear failure state when process-tree termination cannot be confirmed.
+- NAM prerelease versions now compare correctly for A2 compatibility checks instead of being treated as the matching stable release.
+
 ## [0.6.3] - 2026-07-13
 
 ### Added

--- a/build/release-metadata.cjs
+++ b/build/release-metadata.cjs
@@ -1,0 +1,127 @@
+const { appendFileSync, readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
+
+const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/
+
+function parsePackageVersion(packageJsonContent) {
+  let parsed
+  try {
+    parsed = JSON.parse(packageJsonContent)
+  } catch (error) {
+    throw new Error(`package.json is not valid JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+
+  if (!parsed || typeof parsed.version !== 'string' || !SEMVER_PATTERN.test(parsed.version)) {
+    throw new Error('package.json version must be a valid Semantic Version')
+  }
+
+  return parsed.version
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function getReleaseMetadata(packageJsonContent, changelogContent, releaseTag) {
+  const version = parsePackageVersion(packageJsonContent)
+  const versionMatch = SEMVER_PATTERN.exec(version)
+  if (!versionMatch) {
+    throw new Error('Unable to parse package.json version')
+  }
+  const expectedTag = `v${version}`
+
+  if (releaseTag !== expectedTag) {
+    throw new Error(`Release tag ${JSON.stringify(releaseTag)} does not match package.json version ${JSON.stringify(expectedTag)}`)
+  }
+
+  const changelogHeading = new RegExp(`^## \\[${escapeRegExp(version)}\\](?:\\s+-\\s+.+)?\\s*$`, 'm')
+  if (!changelogHeading.test(changelogContent)) {
+    throw new Error(`CHANGELOG.md is missing a release section for ${version}`)
+  }
+
+  return {
+    version,
+    releaseTag: expectedTag,
+    prerelease: versionMatch[4] != null
+  }
+}
+
+function getPreviewMetadata(packageJsonContent, runNumber, commitSha) {
+  const packageVersion = parsePackageVersion(packageJsonContent)
+  const match = SEMVER_PATTERN.exec(packageVersion)
+  if (!match) {
+    throw new Error('Unable to parse package.json version')
+  }
+  if (!/^[1-9]\d*$/.test(runNumber)) {
+    throw new Error('GITHUB_RUN_NUMBER must be a positive integer')
+  }
+  if (!/^[0-9a-fA-F]{7,40}$/.test(commitSha)) {
+    throw new Error('GITHUB_SHA must be a 7-40 character hexadecimal commit hash')
+  }
+
+  const baseVersion = `${match[1]}.${match[2]}.${match[3]}`
+  const shortSha = commitSha.slice(0, 7).toLowerCase()
+  return {
+    baseVersion,
+    previewVersion: `${baseVersion}-preview.${runNumber}.g${shortSha}`,
+    shortSha,
+    previewTag: `preview-main-${runNumber}-${shortSha}`
+  }
+}
+
+function writeOutputs(outputs) {
+  const outputPath = process.env.GITHUB_OUTPUT
+  const lines = Object.entries(outputs).map(([key, value]) => `${key}=${String(value)}`)
+  if (outputPath) {
+    appendFileSync(outputPath, `${lines.join('\n')}\n`, 'utf8')
+  }
+  process.stdout.write(`${lines.join('\n')}\n`)
+}
+
+function run() {
+  const command = process.argv[2]
+  const packageJsonContent = readFileSync(resolve('package.json'), 'utf8')
+
+  if (command === 'release') {
+    const changelogContent = readFileSync(resolve('CHANGELOG.md'), 'utf8')
+    const metadata = getReleaseMetadata(packageJsonContent, changelogContent, process.env.RELEASE_TAG || '')
+    writeOutputs({
+      version: metadata.version,
+      release_tag: metadata.releaseTag,
+      prerelease: metadata.prerelease
+    })
+    return
+  }
+
+  if (command === 'preview') {
+    const metadata = getPreviewMetadata(
+      packageJsonContent,
+      process.env.GITHUB_RUN_NUMBER || '',
+      process.env.GITHUB_SHA || ''
+    )
+    writeOutputs({
+      base_version: metadata.baseVersion,
+      preview_version: metadata.previewVersion,
+      short_sha: metadata.shortSha,
+      preview_tag: metadata.previewTag
+    })
+    return
+  }
+
+  throw new Error('Usage: node build/release-metadata.cjs <release|preview>')
+}
+
+if (require.main === module) {
+  try {
+    run()
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  }
+}
+
+module.exports = {
+  getPreviewMetadata,
+  getReleaseMetadata,
+  parsePackageVersion
+}

--- a/build/release-metadata.test.cjs
+++ b/build/release-metadata.test.cjs
@@ -1,0 +1,66 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  getPreviewMetadata,
+  getReleaseMetadata,
+  parsePackageVersion
+} = require('./release-metadata.cjs')
+
+test('accepts matching stable release metadata', () => {
+  assert.deepEqual(
+    getReleaseMetadata('{"version":"1.2.3"}', '## [1.2.3] - 2026-07-16\n', 'v1.2.3'),
+    { version: '1.2.3', releaseTag: 'v1.2.3', prerelease: false }
+  )
+})
+
+test('marks prerelease package versions as prereleases', () => {
+  assert.deepEqual(
+    getReleaseMetadata('{"version":"1.2.3-rc.2"}', '## [1.2.3-rc.2]\n', 'v1.2.3-rc.2'),
+    { version: '1.2.3-rc.2', releaseTag: 'v1.2.3-rc.2', prerelease: true }
+  )
+})
+
+test('does not mistake hyphenated build metadata for a prerelease', () => {
+  assert.deepEqual(
+    getReleaseMetadata('{"version":"1.2.3+build-2"}', '## [1.2.3+build-2]\n', 'v1.2.3+build-2'),
+    { version: '1.2.3+build-2', releaseTag: 'v1.2.3+build-2', prerelease: false }
+  )
+})
+
+test('rejects a release tag that differs from package.json', () => {
+  assert.throws(
+    () => getReleaseMetadata('{"version":"1.2.3"}', '## [1.2.3]\n', 'v1.2.4'),
+    /does not match/
+  )
+})
+
+test('rejects a release without a matching changelog section', () => {
+  assert.throws(
+    () => getReleaseMetadata('{"version":"1.2.3"}', '## [Unreleased]\n', 'v1.2.3'),
+    /missing a release section/
+  )
+})
+
+test('rejects non-SemVer package versions', () => {
+  assert.throws(() => parsePackageVersion('{"version":"1.02.3"}'), /Semantic Version/)
+})
+
+test('creates a unique SemVer preview version from the run and commit', () => {
+  assert.deepEqual(
+    getPreviewMetadata('{"version":"1.2.3"}', '42', 'ABCDEF0123456789'),
+    {
+      baseVersion: '1.2.3',
+      previewVersion: '1.2.3-preview.42.gabcdef0',
+      shortSha: 'abcdef0',
+      previewTag: 'preview-main-42-abcdef0'
+    }
+  )
+})
+
+test('keeps an all-numeric short SHA valid as a SemVer identifier', () => {
+  const metadata = getPreviewMetadata('{"version":"1.2.3"}', '42', '0123456789abcdef')
+
+  assert.equal(metadata.previewVersion, '1.2.3-preview.42.g0123456')
+  assert.equal(parsePackageVersion(`{"version":"${metadata.previewVersion}"}`), metadata.previewVersion)
+})

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -31,6 +31,9 @@ The Diagnostics screen auto-loads its checks when the page opens.
 - accelerator diagnostics run if there is no current accelerator snapshot
 - training launch diagnostics run if there is no current launch-readiness snapshot
 - the `Re-check All` button refreshes backend, accelerator, training launch, and NAM version checks together
+- a failed automatic request is retained as an error instead of being retried in a render loop
+- failed checks show a visible error and wait for `Re-check All` before trying again
+- results are tied to the settings revision that started them; changing Settings discards stale in-flight results
 
 This keeps the page useful as a quick status check even when the user has not manually triggered anything yet.
 

--- a/docs/jobs-system.md
+++ b/docs/jobs-system.md
@@ -68,6 +68,7 @@ Drafts are where users can iterate safely before they commit a run to the queue.
 - if the batch editor's shared metadata model name is left blank, each generated model uses its output filename; if a shared metadata model name is typed, every generated draft uses that value
 - the template draft, generated drafts, and their later training/finished cards show a `Batch: <template name>` badge for traceability
 - generated drafts are still normal drafts and can be edited independently before queueing
+- all generated drafts are created through one idempotent `jobs:createDraftBatch` operation, so double submission or retry after an interrupted response does not create a partial or duplicate batch
 
 Shared fields copied from the template include:
 
@@ -319,7 +320,9 @@ For queued runs that share the same output root:
 
 - NAM-BOT binds each active run to the timestamped output folder whose folder name time matches that run's start window
 - root-level fallback is only used when fresh training artifacts exist directly in the output root itself
+- NAM-BOT snapshots pre-existing artifacts before launch and ignores unchanged files from that baseline, including recent root-level models
 - this keeps each queued job's log, ESR tracking, and final `.nam` artifact bound to the correct training run even when previous run folders are touched during finalization
+- failed and canceled runs may retain logs and checkpoint diagnostics, but only a successful run with a final `.nam` file can rename, enrich, copy, or publish that model
 
 ### Job Status Values
 
@@ -339,6 +342,10 @@ Stop requests use two modes:
 
 - `graceful`
 - `force`
+
+Stop and application-quit requests cover the complete run lifecycle. During `preparing`, NAM-BOT cancels latency, Lightning, Torch, and other environment subprocesses; after the training PTY starts, the same request controls the full training process tree.
+
+Each run also captures one immutable backend-settings snapshot before preparation. Settings changes made while a job is preparing or running apply to later jobs, not the active run.
 
 ## What The Editor Fields Drive
 
@@ -406,6 +413,8 @@ When a draft is enqueued:
 
 This prevents a user from accidentally changing the meaning of an already queued run.
 
+Queue persistence completes before the draft is removed. A small recovery marker bridges the queue and draft files so a crash between those writes cannot delete the only durable copy of a job.
+
 ### A2 Version Gate
 
 NAM-BOT now defaults to local A2 training through the `a2-packed-wavenet` preset. A2 requires `neural-amp-modeler>=0.13.0` because earlier local `nam-full` installs do not include the required PackedWaveNet training path.
@@ -432,6 +441,8 @@ Saved draft jobs are persisted in the Electron user data folder:
 - Windows: `%APPDATA%\\NAM-BOT\\drafts.json`
 
 This file stores the editable draft list, not the currently open unsaved editor session.
+
+Draft and queue JSON files use atomic replacement and retain a `.bak` recovery copy. Preset, Settings, and update-status persistence use the same storage primitive.
 
 ### Queue Storage
 

--- a/docs/jobs-system.md
+++ b/docs/jobs-system.md
@@ -212,7 +212,7 @@ The queue UI follows the same bottom-first execution model as drafts. The lowest
 Active jobs appear in the training section.
 
 - active jobs surface stop and force-stop controls
-- terminal logs can be expanded and refreshed while a job is active
+- terminal logs can be expanded and refresh incrementally while a job is active; the renderer keeps a bounded tail instead of repeatedly loading the entire file
 - while a run is active, elapsed time is measured from the start of the training run; remaining-time estimates are intentionally not shown because they proved unreliable across NAM training runs
 - expanded active-job details use a compact three-column layout: preset/training facts, ESR comparison, and artifact links
 
@@ -345,6 +345,8 @@ Stop requests use two modes:
 
 Stop and application-quit requests cover the complete run lifecycle. During `preparing`, NAM-BOT cancels latency, Lightning, Torch, and other environment subprocesses; after the training PTY starts, the same request controls the full training process tree.
 
+Force Stop always moves the job to a terminal state after the operating-system kill attempt. A confirmed process-tree termination becomes `canceled`; if termination cannot be confirmed, the job becomes `failed` with a message directing the user to check Task Manager instead of remaining stuck in `stopping`.
+
 Each run also captures one immutable backend-settings snapshot before preparation. Settings changes made while a job is preparing or running apply to later jobs, not the active run.
 
 ## What The Editor Fields Drive
@@ -451,6 +453,8 @@ Queue runtime state is persisted separately:
 - Windows: `%APPDATA%\\NAM-BOT\\queue.json`
 
 This is handled by the queue manager and represents queued, active, and historical runtime items rather than editable drafts.
+
+High-volume terminal progress is coalesced before queue state is written or sent to the renderer. Job progress events are emitted at most four times per second and queue persistence is limited to once per second, while terminal states and explicit queue operations are still persisted immediately.
 
 ### Editor Session Persistence
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,66 @@
+# Release Workflow
+
+NAM-BOT has separate workflows for stable/tagged releases and rolling preview builds. Ordinary branch pushes run CI but do not create a stable GitHub Release.
+
+## Local Release Checks
+
+Run these commands from the repository root before publishing:
+
+```bash
+# Type-check main, preload, renderer, shared code, and tests; run every test; then build all Electron targets.
+npm run check
+
+# Confirm the dependency tree has no known npm advisories.
+npm audit
+```
+
+`npm test` runs the Vitest application suite and the Node release-metadata tests. `npm run build` builds the Electron main, preload, and renderer targets without packaging an installer.
+
+## Stable And Prerelease Tags
+
+`.github/workflows/release.yml` runs for a pushed `v*` tag or a manually selected existing tag. Before packaging, it requires all three of these values to agree:
+
+- the Git tag, such as `v0.6.3`
+- the `package.json` version, such as `0.6.3`
+- a matching `CHANGELOG.md` heading, such as `## [0.6.3] - 2026-07-13`
+
+The workflow stops before packaging if they differ. It also verifies that the tag already exists instead of allowing GitHub CLI to create one implicitly.
+
+A Semantic Version with a prerelease suffix, such as `0.6.4-rc.1`, produces a GitHub prerelease and is not marked as the latest stable release. A version without a suffix produces the latest stable release.
+
+After the release commit has been pushed and smoke-tested, publish the confirmed tag explicitly:
+
+```bash
+# Create the release tag locally after replacing the example with the prepared version.
+git tag v0.6.4
+
+# Push only that tag, which starts the public release workflow.
+git push origin v0.6.4
+```
+
+Do not push a release tag until the user has explicitly confirmed it.
+
+## Preview Builds
+
+`.github/workflows/preview-release.yml` runs on pushes to `main`. It stamps each packaged app with a unique version such as:
+
+```text
+0.6.3-preview.184.ga1b2c3d
+```
+
+The run number and short commit hash keep preview artifacts distinct, including workflow reruns for the same commit. Preview releases are always GitHub prereleases and never replace the latest stable release.
+
+## Packaging Commands
+
+For local packaging:
+
+```bash
+# Build all Electron targets, then package the Windows installer.
+npm run package
+
+# Build and package Windows using the repository's Windows packaging script.
+npm run package:win
+
+# Build and package macOS, then verify the bundled node-pty helper.
+npm run package:mac
+```

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,9 +17,11 @@ Settings in NAM-BOT are automatically saved after a short pause, and the header 
 ### Backend Configuration
 
 - **Conda Executable Path**: Path to the Conda executable NAM-BOT should use. On Windows this is often `conda.exe`; on macOS it is usually `conda`.
-- **Backend Mode**: Choose between using a named Conda environment, a prefix path, or a direct Python executable.
-- **Environment/Python Path**: Specific identifiers for your NAM environment.
+- **Backend Mode**: Choose between using a named Conda environment or an explicit Conda environment prefix.
+- **Environment Name/Prefix**: The identifier for the Conda environment where NAM is installed.
 - **A2 local training requirement**: The selected environment must have `neural-amp-modeler>=0.13.0` for A2 presets. Diagnostics and job enqueue checks use this same backend configuration to detect the installed NAM version.
+
+Older settings files that selected the unsupported Direct Python mode are migrated to the default named Conda environment when loaded.
 
 ### User Information
 
@@ -35,5 +37,5 @@ Settings in NAM-BOT are automatically saved after a short pause, and the header 
 
 - **Automatically open results folder**: Opens the completed run folder in your system file browser once training finishes.
   On Windows this usually means File Explorer. On macOS this means Finder.
-- **Persist queue on exit**: Saves the current job queue to disk so it can be restored on next launch.
-- **Log Retention**: How many days to keep training logs before cleanup.
+
+The job queue is always persisted so that pending and completed jobs survive an app restart. Training logs are retained with their jobs; NAM-BOT does not currently run an age-based log cleanup task.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -4,10 +4,13 @@ The Settings page manages global configuration for NAM-BOT, including backend pa
 
 ## Auto-save Behavior
 
-Settings in NAM-BOT are **automatically saved** as you type. There is no manual "Save" button.
+Settings in NAM-BOT are automatically saved after a short pause, and the header also provides an explicit **Save Settings** button.
 
-- A short debounce (approx. 1 second) is applied to prevent constant disk writes while typing.
-- Backend configuration changes (like Conda or Python paths) are saved immediately, but **validation** of these paths must be triggered manually using the "Validate Backend" button.
+- A short debounce (approximately 500 ms) prevents constant disk writes while typing.
+- Navigating away flushes the current settings draft instead of canceling the pending save.
+- The header reports `Unsaved changes`, `Saving`, `Saved`, or a visible save error.
+- **Validate Backend** first saves the exact settings shown on screen, then validates that saved snapshot.
+- Changing backend settings invalidates earlier backend, accelerator, launch, and NAM-version results so a stale `Backend Ready` result is not displayed for the new target.
 
 ## Configuration Categories
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nam-bot",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nam-bot",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",
@@ -18,9 +18,9 @@
         "node-pty": "^1.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.13.1",
+        "react-router-dom": "^7.18.1",
         "rehype-prism-plus": "^2.0.2",
-        "uuid": "^13.0.0",
+        "uuid": "^13.0.2",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -29,22 +29,22 @@
         "@types/react-dom": "^19.2.3",
         "@types/uuid": "^11.0.0",
         "@vitejs/plugin-react": "^5.1.4",
-        "electron": "^40.8.0",
+        "electron": "^40.10.6",
         "electron-builder": "^26.8.1",
         "electron-vite": "^5.0.0",
         "typescript": "^5.9.3",
-        "vite": "^7.3.1",
-        "vitest": "^3.2.4"
+        "vite": "^7.3.6",
+        "vitest": "^3.2.7"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -63,21 +63,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -94,14 +94,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -111,14 +111,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -138,29 +138,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -200,9 +200,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -210,27 +210,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -297,33 +297,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -331,14 +331,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -415,6 +415,16 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -441,9 +451,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -519,25 +529,50 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
         "progress": "^2.0.3",
-        "semver": "^6.2.0",
+        "semver": "^7.6.3",
         "sumchecker": "^3.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22.12.0"
       },
       "optionalDependencies": {
-        "global-agent": "^3.0.0"
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@electron/notarize": {
@@ -735,9 +770,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2222,17 +2257,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@uiw/react-textarea-code-editor": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@uiw/react-textarea-code-editor/-/react-textarea-code-editor-3.1.1.tgz",
@@ -2365,15 +2389,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -2382,13 +2406,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -2409,9 +2433,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2422,13 +2446,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.7",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -2437,13 +2461,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -2452,9 +2476,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2465,13 +2489,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -2480,9 +2504,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2857,9 +2881,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2891,9 +2915,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2904,9 +2928,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
       "dev": true,
       "funding": [
         {
@@ -2924,11 +2948,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2960,16 +2984,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -3098,9 +3112,9 @@
       "license": "MIT"
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3196,9 +3210,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001777",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -3788,9 +3802,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3961,22 +3975,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.8.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.8.0.tgz",
-      "integrity": "sha512-WoPq0Nr9Yx3g7T6VnJXdwa/rr2+VRyH3a+K+ezfMKBlf6WjxE/LmhMQabKbb6yjm9RbZhJBRcYyoLph421O2mQ==",
+      "version": "40.10.6",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.6.tgz",
+      "integrity": "sha512-TGjlkOU9Lg6K4KjDbsErywCWCIDaNgLh0q+xj0nlpRoQhevI7VBIxBTtJI/V30lypyLAaXMpnP9O9jui1/qRFw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
         "electron": "cli.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
@@ -4121,9 +4135,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.307",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "version": "1.5.392",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
+      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
       "dev": true,
       "license": "ISC"
     },
@@ -4432,27 +4446,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/extsprintf": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
@@ -4477,16 +4470,6 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4524,9 +4507,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4577,35 +4560,20 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs-minipass": {
@@ -4758,9 +4726,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4932,9 +4900,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5235,9 +5203,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5408,10 +5376,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5496,9 +5474,9 @@
       "license": "MIT"
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -5970,9 +5948,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -6110,11 +6088,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nopt": {
       "version": "8.1.0",
@@ -6371,13 +6352,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6386,9 +6360,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6414,9 +6388,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -6434,7 +6408,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6594,9 +6568,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -6616,12 +6590,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -7316,9 +7290,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -7488,9 +7462,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7569,6 +7543,17 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -7768,9 +7753,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -7839,13 +7824,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -7937,9 +7922,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -7954,9 +7939,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -7971,9 +7956,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -7988,9 +7973,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -8005,9 +7990,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -8022,9 +8007,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -8039,9 +8024,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -8056,9 +8041,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -8073,9 +8058,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -8090,9 +8075,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -8107,9 +8092,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -8124,9 +8109,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -8141,9 +8126,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -8158,9 +8143,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -8175,9 +8160,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -8192,9 +8177,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -8209,9 +8194,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -8226,9 +8211,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -8243,9 +8228,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -8260,9 +8245,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -8277,9 +8262,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -8294,9 +8279,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -8311,9 +8296,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -8328,9 +8313,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -8345,9 +8330,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -8362,9 +8347,9 @@
       }
     },
     "node_modules/vite/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -8379,9 +8364,9 @@
       }
     },
     "node_modules/vite/node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -8392,49 +8377,49 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -8464,8 +8449,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -8644,17 +8629,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nam-bot",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nam-bot",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.6",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "nam-bot",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Neural Amp Modeler Training Manager",
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.node.json --pretty false && tsc -p tsconfig.web.json --pretty false && tsc -p tsconfig.test.json --pretty false",
+    "check": "npm run typecheck && npm test && npm run build",
     "preview": "electron-vite preview",
     "package": "npm run build && electron-builder --win --config electron-builder.yml",
     "package:mac": "npm run build && electron-builder --mac --config electron-builder.yml && node build/verify-macos-node-pty.cjs release",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "nam-bot",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Neural Amp Modeler Training Manager",
   "main": "./out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",
-    "test": "vitest run",
+    "test": "vitest run && node --test build/release-metadata.test.cjs",
     "typecheck": "tsc -p tsconfig.node.json --pretty false && tsc -p tsconfig.web.json --pretty false && tsc -p tsconfig.test.json --pretty false",
     "check": "npm run typecheck && npm test && npm run build",
     "preview": "electron-vite preview",
@@ -43,12 +43,12 @@
     "@types/react-dom": "^19.2.3",
     "@types/uuid": "^11.0.0",
     "@vitejs/plugin-react": "^5.1.4",
-    "electron": "^40.8.0",
+    "electron": "^40.10.6",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
     "typescript": "^5.9.3",
-    "vite": "^7.3.1",
-    "vitest": "^3.2.4"
+    "vite": "^7.3.6",
+    "vitest": "^3.2.7"
   },
   "dependencies": {
     "@babel/runtime": "^7.28.6",
@@ -60,9 +60,9 @@
     "node-pty": "^1.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.13.1",
+    "react-router-dom": "^7.18.1",
     "rehype-prism-plus": "^2.0.2",
-    "uuid": "^13.0.0",
+    "uuid": "^13.0.2",
     "zustand": "^5.0.11"
   }
 }

--- a/src/main/backend/adapter.test.ts
+++ b/src/main/backend/adapter.test.ts
@@ -15,6 +15,21 @@ describe('compareVersions', () => {
     expect(compareVersions('0.13.1', '0.13.0')).toBeGreaterThan(0)
     expect(compareVersions('0.12.3', '0.13.0')).toBeLessThan(0)
   })
+
+  it('treats NAM prereleases as older than the matching stable release', () => {
+    expect(compareVersions('0.13.0rc1', '0.13.0')).toBeLessThan(0)
+    expect(compareVersions('0.13.0-rc.2', '0.13.0')).toBeLessThan(0)
+    expect(compareVersions('0.13.0-beta3', '0.13.0')).toBeLessThan(0)
+  })
+
+  it('orders compact NAM prerelease revisions numerically', () => {
+    expect(compareVersions('0.13.0rc10', '0.13.0rc2')).toBeGreaterThan(0)
+    expect(compareVersions('v0.13.0a2', '0.13.0a10')).toBeLessThan(0)
+  })
+
+  it('ignores NAM build metadata', () => {
+    expect(compareVersions('0.13.0+cuda', '0.13.0')).toBe(0)
+  })
 })
 
 describe('parseNamLatencyAnalysisOutput', () => {

--- a/src/main/backend/adapter.ts
+++ b/src/main/backend/adapter.ts
@@ -176,6 +176,7 @@ function createAcceleratorDiagnosticsSummary(
     torchImportOk: extras?.torchImportOk ?? null,
     torchVersion: extras?.torchVersion ?? null,
     torchCudaVersion: extras?.torchCudaVersion ?? null,
+    hipVersion: extras?.hipVersion ?? null,
     namVersion: extras?.namVersion ?? null,
     lightningPackage: extras?.lightningPackage ?? null,
     lightningVersion: extras?.lightningVersion ?? null,
@@ -1094,9 +1095,15 @@ export async function validateBackend(settings: AppSettings): Promise<BackendVal
 
 async function runCondaCommand(
   settings: AppSettings,
-  args: string[]
+  args: string[],
+  signal?: AbortSignal
 ): Promise<{ ok: boolean; output: string }> {
   return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve({ ok: false, output: 'Command canceled' })
+      return
+    }
+
     let proc: ChildProcess
     try {
       proc = spawnCondaProcess(settings, args)
@@ -1110,14 +1117,29 @@ async function runCondaCommand(
     let output = ''
     let errorOutput = ''
     let settled = false
+    let timeout: NodeJS.Timeout | null = null
 
     const settle = (result: { ok: boolean; output: string }): void => {
       if (settled) {
         return
       }
       settled = true
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+      signal?.removeEventListener('abort', handleAbort)
       resolve(result)
     }
+
+    const handleAbort = (): void => {
+      if (settled) {
+        return
+      }
+      forceKillProcessTreeSync(proc)
+      settle({ ok: false, output: 'Command canceled' })
+    }
+
+    signal?.addEventListener('abort', handleAbort, { once: true })
 
     proc.stdout?.on('data', (data: Buffer | string) => {
       output += data.toString()
@@ -1138,7 +1160,7 @@ async function runCondaCommand(
       settle({ ok: false, output: err.message })
     })
 
-    setTimeout(async () => {
+    timeout = setTimeout(async () => {
       if (settled) {
         return
       }
@@ -1151,14 +1173,15 @@ async function runCondaCommand(
 async function runPythonScriptInEnvironment(
   settings: AppSettings,
   script: string,
-  scriptName: string
+  scriptName: string,
+  signal?: AbortSignal
 ): Promise<{ ok: boolean; output: string }> {
   const tempDir = mkdtempSync(join(tmpdir(), 'nam-bot-probe-'))
   const scriptPath = join(tempDir, scriptName)
 
   try {
     writeFileSync(scriptPath, script, 'utf8')
-    return await runCondaCommand(settings, ['python', scriptPath])
+    return await runCondaCommand(settings, ['python', scriptPath], signal)
   } finally {
     rmSync(tempDir, { recursive: true, force: true })
   }
@@ -1174,7 +1197,10 @@ function getLightningSecurityCacheKey(settings: AppSettings): string {
   })
 }
 
-async function runLightningPackageSecurityProbe(settings: AppSettings): Promise<LightningSecuritySummary> {
+async function runLightningPackageSecurityProbe(
+  settings: AppSettings,
+  signal?: AbortSignal
+): Promise<LightningSecuritySummary> {
   const script = [
     'import json',
     'from importlib.metadata import PackageNotFoundError, version',
@@ -1195,7 +1221,7 @@ async function runLightningPackageSecurityProbe(settings: AppSettings): Promise<
     `print('${LIGHTNING_SECURITY_PREFIX}' + json.dumps({'packages': packages}))`
   ].join('\n')
 
-  const result = await runPythonScriptInEnvironment(settings, script, 'lightning-security-probe.py')
+  const result = await runPythonScriptInEnvironment(settings, script, 'lightning-security-probe.py', signal)
   const line = result.output
     .split(/\r?\n/)
     .find((entry) => entry.trim().startsWith(LIGHTNING_SECURITY_PREFIX))
@@ -1237,7 +1263,7 @@ async function runLightningPackageSecurityProbe(settings: AppSettings): Promise<
 
 async function inspectLightningPackageSecurity(
   settings: AppSettings,
-  options?: { allowRecentResult?: boolean }
+  options?: { allowRecentResult?: boolean; signal?: AbortSignal }
 ): Promise<LightningSecuritySummary> {
   const cacheKey = getLightningSecurityCacheKey(settings)
   const allowRecentResult = options?.allowRecentResult ?? true
@@ -1245,6 +1271,14 @@ async function inspectLightningPackageSecurity(
   if (allowRecentResult && recentResult && Date.now() - recentResult.checkedAt < LIGHTNING_SECURITY_RECENT_RESULT_TTL_MS) {
     log.info('Reusing recent Lightning security probe result')
     return recentResult.summary
+  }
+
+  if (options?.signal) {
+    const summary = await runLightningPackageSecurityProbe(settings, options.signal)
+    if (!options.signal.aborted) {
+      lightningSecurityRecentResults.set(cacheKey, { checkedAt: Date.now(), summary })
+    }
+    return summary
   }
 
   const inFlight = lightningSecurityInFlight.get(cacheKey)
@@ -1265,8 +1299,13 @@ async function inspectLightningPackageSecurity(
   return probe
 }
 
-async function assertLightningPackageSafe(settings: AppSettings): Promise<void> {
-  const lightningSecurity = await inspectLightningPackageSecurity(settings, { allowRecentResult: false })
+async function assertLightningPackageSafe(settings: AppSettings, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted()
+  const lightningSecurity = await inspectLightningPackageSecurity(settings, {
+    allowRecentResult: false,
+    signal
+  })
+  signal?.throwIfAborted()
   if (!lightningSecurity.ok) {
     throw new Error('NAM-BOT could not verify Lightning package versions safely. Verify package metadata manually before running NAM commands in this environment.')
   }
@@ -1277,7 +1316,10 @@ async function assertLightningPackageSafe(settings: AppSettings): Promise<void> 
   }
 }
 
-export async function inspectTorchRuntime(settings: AppSettings): Promise<TorchRuntimeSummary | null> {
+export async function inspectTorchRuntime(
+  settings: AppSettings,
+  signal?: AbortSignal
+): Promise<TorchRuntimeSummary | null> {
   const script = [
     'import json',
     'import torch',
@@ -1293,7 +1335,8 @@ export async function inspectTorchRuntime(settings: AppSettings): Promise<TorchR
     "print('NAM_BOT_TORCH=' + json.dumps(payload))"
   ].join('\n')
 
-  const result = await runPythonScriptInEnvironment(settings, script, 'torch-runtime-probe.py')
+  const result = await runPythonScriptInEnvironment(settings, script, 'torch-runtime-probe.py', signal)
+  signal?.throwIfAborted()
   if (!result.ok && !result.output.includes('NAM_BOT_TORCH=')) {
     return null
   }
@@ -2228,17 +2271,21 @@ function buildNamLatencyAnalysisScript(inputPath: string, outputPath: string): s
 export async function analyzeNamLatency(
   settings: AppSettings,
   inputPath: string,
-  outputPath: string
+  outputPath: string,
+  signal?: AbortSignal
 ): Promise<NamLatencyAnalysisResult> {
   try {
-    await assertLightningPackageSafe(settings)
+    await assertLightningPackageSafe(settings, signal)
   } catch (error) {
+    signal?.throwIfAborted()
     const message = error instanceof Error ? error.message : 'Lightning package security check failed'
     return createFailedLatencyAnalysis('', message)
   }
 
   const script = buildNamLatencyAnalysisScript(inputPath, outputPath)
-  const result = await runPythonScriptInEnvironment(settings, script, 'latency-analysis.py')
+  signal?.throwIfAborted()
+  const result = await runPythonScriptInEnvironment(settings, script, 'latency-analysis.py', signal)
+  signal?.throwIfAborted()
   const parsed = parseNamLatencyAnalysisOutput(result.output)
 
   if (!result.ok && !parsed.errorMessage) {
@@ -2259,9 +2306,11 @@ export async function runNamFull(
     noPlots?: boolean
     cwd?: string
   },
-  hooks: RunHooks
+  hooks: RunHooks,
+  signal?: AbortSignal
 ): Promise<TrainingProcessController> {
-  await assertLightningPackageSafe(settings)
+  await assertLightningPackageSafe(settings, signal)
+  signal?.throwIfAborted()
 
   return new Promise((resolve, reject) => {
     const namArgs = [
@@ -2300,8 +2349,15 @@ export async function runNamFull(
     })
 
     pty.onExit(({ exitCode }) => {
+      signal?.removeEventListener('abort', handleAbort)
       hooks.onExit(exitCode)
     })
+
+    const handleAbort = (): void => {
+      forceKillPtyProcessTreeSync(pty)
+    }
+
+    signal?.addEventListener('abort', handleAbort, { once: true })
 
     resolve({
       cancel: () => {

--- a/src/main/backend/adapter.ts
+++ b/src/main/backend/adapter.ts
@@ -7,6 +7,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, wri
 import { spawn as spawnPty, IPty } from 'node-pty'
 import { tmpdir } from 'os'
 import { join, dirname } from 'path'
+import { compareAppVersions } from '../../shared/version'
 import {
   AcceleratorDiagnosticsSummary,
   AppSettings,
@@ -119,7 +120,7 @@ export interface NamLatencyAnalysisResult {
 
 export interface TrainingProcessController {
   cancel: () => void
-  forceKill: () => Promise<void>
+  forceKill: () => Promise<boolean>
   forceKillSync: () => void
 }
 
@@ -762,7 +763,7 @@ function runCondaPtyCommand(
   })
 }
 
-function taskkill(pid: number, force: boolean): Promise<void> {
+function taskkill(pid: number, force: boolean): Promise<boolean> {
   return new Promise((resolve) => {
     const args = ['/PID', String(pid), '/T']
     if (force) {
@@ -776,53 +777,56 @@ function taskkill(pid: number, force: boolean): Promise<void> {
 
     killer.on('error', (error) => {
       log.warn('taskkill failed:', error)
-      resolve()
+      resolve(false)
     })
 
-    killer.on('close', () => resolve())
+    killer.on('close', (code) => resolve(code === 0))
   })
 }
 
-async function forceKillProcessTree(proc: ChildProcess): Promise<void> {
+async function forceKillProcessTree(proc: ChildProcess): Promise<boolean> {
   if (!proc.pid) {
-    return
+    return true
   }
 
   if (process.platform === 'win32') {
-    await taskkill(proc.pid, true)
-    return
+    return await taskkill(proc.pid, true)
   }
 
   try {
     process.kill(-proc.pid, 'SIGKILL')
+    return true
   } catch (error) {
     log.warn('Failed to SIGKILL process group, falling back to child.kill():', error)
     try {
-      proc.kill('SIGKILL')
+      return proc.kill('SIGKILL')
     } catch (innerError) {
       log.warn('Failed to SIGKILL child process:', innerError)
+      return false
     }
   }
 }
 
-async function forceKillPtyProcessTree(pty: IPty): Promise<void> {
+async function forceKillPtyProcessTree(pty: IPty): Promise<boolean> {
   if (!pty.pid) {
-    return
+    return true
   }
 
   if (process.platform === 'win32') {
-    await taskkill(pty.pid, true)
-    return
+    return await taskkill(pty.pid, true)
   }
 
   try {
     process.kill(-pty.pid, 'SIGKILL')
+    return true
   } catch (error) {
     log.warn('Failed to SIGKILL PTY process group, falling back to pty.kill():', error)
     try {
       pty.kill()
+      return true
     } catch (innerError) {
       log.warn('Failed to kill PTY process:', innerError)
+      return false
     }
   }
 }
@@ -1192,8 +1196,7 @@ function getLightningSecurityCacheKey(settings: AppSettings): string {
     backendMode: settings.backendMode,
     condaExecutablePath: settings.condaExecutablePath ?? null,
     environmentName: settings.environmentName ?? null,
-    environmentPrefixPath: settings.environmentPrefixPath ?? null,
-    pythonExecutablePath: settings.pythonExecutablePath ?? null
+    environmentPrefixPath: settings.environmentPrefixPath ?? null
   })
 }
 
@@ -1733,34 +1736,6 @@ export async function inspectTrainingLaunchDiagnostics(
   const appLocationCheck = createMacAppLocationCheck()
   if (appLocationCheck) {
     checks.push(appLocationCheck)
-  }
-
-  if (settings.backendMode === 'direct-python') {
-    checks.push(
-      createTrainingLaunchCheck(
-        'fail',
-        'direct_python_unsupported',
-        'Training launch mode',
-        'Direct Python mode is not supported by the current training launch path.',
-        {
-          detail: settings.pythonExecutablePath ?? 'No Python executable configured',
-          suggestion: 'Use Conda environment name or Conda prefix mode for training launch readiness.'
-        }
-      ),
-      createTrainingLaunchCheck('skip', 'pty_python_skipped', 'PTY Python launch', 'Skipped because direct Python launch is not wired to the trainer yet.'),
-      createTrainingLaunchCheck('skip', 'nam_full_pty_skipped', 'nam-full PTY launch', 'Skipped because direct Python launch is not wired to the trainer yet.')
-    )
-
-    return createTrainingLaunchDiagnosticsSummary(
-      'error',
-      'direct_python_unsupported',
-      'Training launch is not ready',
-      'NAM-BOT currently launches training through Conda, but Settings is using Direct Python mode.',
-      {
-        checks,
-        suggestion: 'Switch Settings to a Conda environment name or prefix before training.'
-      }
-    )
   }
 
   const condaExecutablePath = settings.condaExecutablePath?.trim() ?? ''
@@ -2366,7 +2341,7 @@ export async function runNamFull(
       },
       forceKill: async () => {
         log.info('Force-killing nam-full PTY process tree')
-        await forceKillPtyProcessTree(pty)
+        return await forceKillPtyProcessTree(pty)
       },
       forceKillSync: () => {
         log.info('Synchronously force-killing nam-full PTY process tree')
@@ -2617,16 +2592,25 @@ export async function getNamVersionInfo(settings: AppSettings): Promise<NamVersi
 }
 
 export function compareVersions(a: string, b: string): number {
-  const aParts = a.split('.').map((part) => parseInt(part.replace(/[^0-9]/g, ''), 10) || 0)
-  const bParts = b.split('.').map((part) => parseInt(part.replace(/[^0-9]/g, ''), 10) || 0)
-  
-  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
-    const aPart = aParts[i] ?? 0
-    const bPart = bParts[i] ?? 0
-    if (aPart !== bPart) {
-      return aPart - bPart
-    }
+  return compareAppVersions(normalizeNamVersion(a), normalizeNamVersion(b))
+}
+
+function normalizeNamVersion(version: string): string {
+  const normalized = version.trim().replace(/^v/i, '')
+  const compactPrerelease = /^(\d+(?:\.\d+){0,2})-?(a|alpha|b|beta|rc|pre|preview|dev)[.-]?(\d*)(\+.*)?$/i.exec(normalized)
+  if (!compactPrerelease) {
+    return normalized
   }
-  
-  return 0
+
+  const label = compactPrerelease[2].toLowerCase()
+  const canonicalLabel = label === 'a'
+    ? 'alpha'
+    : label === 'b'
+      ? 'beta'
+      : label === 'pre' || label === 'preview'
+        ? 'rc'
+        : label
+  const revision = compactPrerelease[3] || '0'
+  const buildMetadata = compactPrerelease[4] ?? ''
+  return `${compactPrerelease[1]}-${canonicalLabel}.${revision}${buildMetadata}`
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,18 @@
-import { app, BrowserWindow, dialog, ipcMain, nativeImage, Notification, powerSaveBlocker, shell, type NativeImage } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  nativeImage,
+  Notification,
+  powerSaveBlocker,
+  shell,
+  type MessageBoxOptions,
+  type MessageBoxReturnValue,
+  type NativeImage
+} from 'electron'
 import { join } from 'path'
+import { pathToFileURL } from 'url'
 import log from 'electron-log/main'
 import { existsSync, mkdirSync } from 'fs'
 import { setupIpcHandlers, validateBackendOnStartup } from './ipc/settings'
@@ -70,6 +83,12 @@ let allowUnsafeClose = false
 let trainingPowerSaveBlockerId: number | null = null
 const reportedFinishedStatuses: Map<string, JobStatus> = new Map()
 const reportedDiagnosticBlocks: Set<string> = new Set()
+
+function showMainMessageBox(options: MessageBoxOptions): Promise<MessageBoxReturnValue> {
+  return mainWindow
+    ? dialog.showMessageBox(mainWindow, options)
+    : dialog.showMessageBox(options)
+}
 
 app.setAppUserModelId(APP_ID)
 
@@ -159,7 +178,7 @@ function stopTrainingPowerSaveBlocker(): void {
 }
 
 async function showAboutDialog(): Promise<void> {
-  const result = await dialog.showMessageBox(mainWindow ?? undefined, {
+  const result = await showMainMessageBox({
     type: 'info',
     title: 'About NAM-BOT',
     message: `NAM-BOT ${app.getVersion()}`,
@@ -184,7 +203,7 @@ async function showManualUpdateCheckDialog(): Promise<void> {
     const status = await checkForUpdatesNow()
 
     if (status.state === 'update-available' && status.latestVersion) {
-      const result = await dialog.showMessageBox(mainWindow ?? undefined, {
+      const result = await showMainMessageBox({
         type: 'info',
         title: 'Update Available',
         message: `NAM-BOT ${status.latestVersion} is available.`,
@@ -202,7 +221,7 @@ async function showManualUpdateCheckDialog(): Promise<void> {
     }
 
     if (status.state === 'up-to-date') {
-      await dialog.showMessageBox(mainWindow ?? undefined, {
+      await showMainMessageBox({
         type: 'info',
         title: 'No Updates Available',
         message: `NAM-BOT ${status.currentVersion} is up to date.`,
@@ -216,7 +235,7 @@ async function showManualUpdateCheckDialog(): Promise<void> {
       return
     }
 
-    await dialog.showMessageBox(mainWindow ?? undefined, {
+    await showMainMessageBox({
       type: 'warning',
       title: 'Update Check Failed',
       message: 'NAM-BOT could not confirm the latest release right now.',
@@ -227,7 +246,7 @@ async function showManualUpdateCheckDialog(): Promise<void> {
     })
   } catch (error) {
     log.error('Manual update dialog flow failed:', error)
-    await dialog.showMessageBox(mainWindow ?? undefined, {
+    await showMainMessageBox({
       type: 'error',
       title: 'Update Check Failed',
       message: 'NAM-BOT could not complete the manual update check.',
@@ -351,6 +370,8 @@ function setupShellIntegrations(): void {
 function createWindow(): void {
   log.info('Creating main window...')
   const windowIcon = resolveWindowIcon()
+  const bundledRendererPath = join(__dirname, '../renderer/index.html')
+  const bundledRendererUrl = pathToFileURL(bundledRendererPath)
 
   mainWindow = new BrowserWindow({
     width: 1400,
@@ -364,7 +385,7 @@ function createWindow(): void {
       preload: join(__dirname, '../preload/index.js'),
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false
+      sandbox: true
     }
   })
 
@@ -377,9 +398,50 @@ function createWindow(): void {
     updateWindowProgress()
   })
 
+  const trustedExternalHosts = new Set([
+    'github.com',
+    'daveotero.com',
+    'flatlineaudio.com',
+    'ko-fi.com',
+    'www.anaconda.com',
+    'pytorch.org',
+    'www.pytorch.org'
+  ])
+  const isTrustedRendererUrl = (targetUrl: string): boolean => {
+    try {
+      const parsedUrl = new URL(targetUrl)
+      if (isDev && process.env['ELECTRON_RENDERER_URL']) {
+        return parsedUrl.origin === new URL(process.env['ELECTRON_RENDERER_URL']).origin
+      }
+      return parsedUrl.protocol === 'file:' && parsedUrl.pathname === bundledRendererUrl.pathname
+    } catch {
+      return false
+    }
+  }
+
+  mainWindow.webContents.on('will-navigate', (event, targetUrl) => {
+    if (!isTrustedRendererUrl(targetUrl)) {
+      event.preventDefault()
+      log.warn('Blocked unexpected renderer navigation:', targetUrl)
+    }
+  })
+
   mainWindow.webContents.setWindowOpenHandler((details) => {
-    shell.openExternal(details.url)
+    try {
+      const targetUrl = new URL(details.url)
+      if (targetUrl.protocol === 'https:' && trustedExternalHosts.has(targetUrl.hostname)) {
+        void shell.openExternal(targetUrl.toString())
+      } else {
+        log.warn('Blocked untrusted external URL:', details.url)
+      }
+    } catch {
+      log.warn('Blocked malformed external URL:', details.url)
+    }
     return { action: 'deny' }
+  })
+
+  mainWindow.webContents.session.setPermissionRequestHandler((_webContents, _permission, callback) => {
+    callback(false)
   })
 
   mainWindow.on('close', (event) => {
@@ -388,7 +450,7 @@ function createWindow(): void {
     }
 
     event.preventDefault()
-    void dialog.showMessageBox(mainWindow ?? undefined, {
+    void showMainMessageBox({
       type: 'warning',
       title: 'Training is still running',
       message: 'Closing NAM-BOT right now will force-stop the active training job.',
@@ -412,7 +474,7 @@ function createWindow(): void {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
     log.info('Loading production build')
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    mainWindow.loadFile(bundledRendererPath)
   }
 
   mainWindow.webContents.once('did-finish-load', () => {

--- a/src/main/ipc/jobs.ts
+++ b/src/main/ipc/jobs.ts
@@ -1,14 +1,37 @@
 import { app, BrowserWindow, dialog, ipcMain, shell } from 'electron'
-import { existsSync, copyFileSync, readFileSync, statSync, writeFileSync } from 'fs'
+import { existsSync, copyFileSync, readFileSync, statSync } from 'fs'
 import log from 'electron-log/main'
 import { join } from 'path'
 import { v4 as uuidv4 } from 'uuid'
 import { getQueueManager } from '../jobs/queueManager'
 import { loadSettings } from '../persistence/settingsStore'
 import { JobRuntimeState, JobSpec, defaultJobSpec, normalizeJobSpec } from '../types/jobs'
+import {
+  atomicWriteJsonSync,
+  readJsonWithBackupSync,
+  removeFileIfExistsSync
+} from '../persistence/atomicFile'
 
 const draftsPath = join(app.getPath('userData'), 'drafts.json')
+const draftQueueTransactionPath = join(app.getPath('userData'), 'draft-queue-transaction.json')
 const drafts: Map<string, JobSpec> = new Map()
+
+interface DraftQueueTransaction {
+  draftIds: string[]
+  queuedJobIds: string[]
+}
+
+interface DraftBatchSource {
+  kind: 'draft' | 'runtime'
+  id: string
+}
+
+interface DraftBatchRequest {
+  batchId: string
+  batchSourceName: string
+  drafts: unknown[]
+  source: DraftBatchSource | null
+}
 
 type JobArtifactTarget = 'workspace' | 'output' | 'workspace-log' | 'run-log' | 'model'
 
@@ -61,8 +84,16 @@ function cloneJobSpec(job: JobSpec): JobSpec {
   return JSON.parse(JSON.stringify(job)) as JobSpec
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function saveDraftCollection(collection: Map<string, JobSpec>): void {
+  atomicWriteJsonSync(draftsPath, Array.from(collection.values()))
+}
+
 function saveDrafts(): void {
-  writeFileSync(draftsPath, JSON.stringify(Array.from(drafts.values()), null, 2), 'utf-8')
+  saveDraftCollection(drafts)
 }
 
 function loadDrafts(): void {
@@ -71,7 +102,7 @@ function loadDrafts(): void {
   }
 
   try {
-    const parsed = JSON.parse(readFileSync(draftsPath, 'utf-8')) as unknown
+    const parsed = readJsonWithBackupSync(draftsPath)
     if (!Array.isArray(parsed)) {
       return
     }
@@ -91,17 +122,80 @@ function loadDrafts(): void {
   }
 }
 
-function createDraftFromInput(input?: Partial<JobSpec>): JobSpec {
+function createDraftFromInput(input?: unknown): JobSpec {
   const now = new Date().toISOString()
   const normalized = normalizeJobSpec(input)
+  const candidate = isRecord(input) ? input : {}
   return {
     ...JSON.parse(JSON.stringify(defaultJobSpec)) as Omit<JobSpec, 'id' | 'createdAt' | 'updatedAt'>,
     ...normalized,
-    id: input?.id ?? uuidv4(),
+    id: typeof candidate.id === 'string' && candidate.id.length > 0 ? candidate.id : uuidv4(),
     name: normalized.name || 'New Job',
-    createdAt: input?.createdAt ?? now,
+    createdAt: typeof candidate.createdAt === 'string' ? candidate.createdAt : now,
     updatedAt: now
   }
+}
+
+function parseDraftBatchRequest(input: unknown): DraftBatchRequest {
+  if (!isRecord(input)
+    || typeof input.batchId !== 'string'
+    || input.batchId.trim().length === 0
+    || typeof input.batchSourceName !== 'string'
+    || !Array.isArray(input.drafts)
+    || input.drafts.length === 0) {
+    throw new Error('Invalid draft batch request.')
+  }
+
+  let source: DraftBatchSource | null = null
+  if (isRecord(input.source)) {
+    const kind = input.source.kind
+    const id = input.source.id
+    if ((kind === 'draft' || kind === 'runtime') && typeof id === 'string' && id.length > 0) {
+      source = { kind, id }
+    }
+  }
+
+  return {
+    batchId: input.batchId,
+    batchSourceName: input.batchSourceName.trim() || 'Batch Training',
+    drafts: input.drafts,
+    source
+  }
+}
+
+function recoverDraftQueueTransaction(queueManager: ReturnType<typeof getQueueManager>): void {
+  if (!existsSync(draftQueueTransactionPath)) {
+    return
+  }
+
+  try {
+    const parsed = readJsonWithBackupSync(draftQueueTransactionPath)
+    if (!isRecord(parsed) || !Array.isArray(parsed.draftIds) || !Array.isArray(parsed.queuedJobIds)) {
+      removeFileIfExistsSync(draftQueueTransactionPath)
+      return
+    }
+
+    const draftIds = parsed.draftIds.filter((value): value is string => typeof value === 'string')
+    const queuedJobIds = parsed.queuedJobIds.filter((value): value is string => typeof value === 'string')
+    const durableQueueIds = new Set(queueManager.getQueue().map((runtime) => runtime.jobId))
+    if (queuedJobIds.length > 0 && queuedJobIds.every((jobId) => durableQueueIds.has(jobId))) {
+      for (const draftId of draftIds) {
+        drafts.delete(draftId)
+      }
+      saveDrafts()
+    }
+    removeFileIfExistsSync(draftQueueTransactionPath)
+  } catch (error) {
+    log.error('Failed to recover draft-to-queue transaction:', error)
+  }
+}
+
+function beginDraftQueueTransaction(transaction: DraftQueueTransaction): void {
+  atomicWriteJsonSync(draftQueueTransactionPath, transaction)
+}
+
+function finishDraftQueueTransaction(): void {
+  removeFileIfExistsSync(draftQueueTransactionPath)
 }
 
 function broadcastQueue(queue: JobRuntimeState[]): void {
@@ -122,6 +216,7 @@ export function setupJobIpcHandlers(): void {
 
   const queueManager = getQueueManager()
   queueManager.setSettings(loadSettings())
+  recoverDraftQueueTransaction(queueManager)
 
   queueManager.on('queueUpdated', (queue: JobRuntimeState[]) => {
     broadcastQueue(queue)
@@ -136,6 +231,60 @@ export function setupJobIpcHandlers(): void {
     drafts.set(job.id, job)
     saveDrafts()
     return job
+  })
+
+  ipcMain.handle('jobs:createDraftBatch', async (_event, input: unknown) => {
+    const request = parseDraftBatchRequest(input)
+    const existing = Array.from(drafts.values()).filter((draft) => draft.batchId === request.batchId)
+    if (existing.length > 0) {
+      const existingPaths = new Set(existing.map((draft) => draft.outputAudioPath))
+      const requestedPaths = new Set(request.drafts.map((draft) => normalizeJobSpec(draft).outputAudioPath))
+      if (existingPaths.size !== requestedPaths.size
+        || Array.from(requestedPaths).some((outputPath) => !existingPaths.has(outputPath))) {
+        throw new Error(`Batch ${request.batchId} already exists with different output files.`)
+      }
+      return existing
+    }
+
+    const created = request.drafts.map((draftInput) => createDraftFromInput({
+      ...normalizeJobSpec(draftInput),
+      batchId: request.batchId,
+      batchSourceName: request.batchSourceName
+    }))
+    const nextDrafts = new Map(drafts)
+    for (const draft of created) {
+      nextDrafts.set(draft.id, draft)
+    }
+    if (request.source?.kind === 'draft') {
+      const sourceDraft = nextDrafts.get(request.source.id)
+      if (sourceDraft) {
+        nextDrafts.set(sourceDraft.id, {
+          ...sourceDraft,
+          batchId: request.batchId,
+          batchSourceName: request.batchSourceName,
+          updatedAt: new Date().toISOString()
+        })
+      }
+    }
+
+    saveDraftCollection(nextDrafts)
+    drafts.clear()
+    for (const [draftId, draft] of nextDrafts) {
+      drafts.set(draftId, draft)
+    }
+
+    if (request.source?.kind === 'runtime') {
+      try {
+        queueManager.tagQueueItemBatch(
+          request.source.id,
+          request.batchId,
+          request.batchSourceName
+        )
+      } catch (error) {
+        log.error('Batch drafts were saved, but tagging the runtime source failed:', error)
+      }
+    }
+    return created
   })
 
   ipcMain.handle('jobs:saveDraft', async (_event, job: JobSpec) => {
@@ -192,9 +341,20 @@ export function setupJobIpcHandlers(): void {
     frozenSpec.id = taskId
     frozenSpec.updatedAt = new Date().toISOString()
     await queueManager.validateJobCanTrain(frozenSpec)
-    queueManager.addToQueue(frozenSpec)
+    beginDraftQueueTransaction({ draftIds: [draftId], queuedJobIds: [frozenSpec.id] })
+    try {
+      queueManager.addToQueue(frozenSpec)
+    } catch (error) {
+      finishDraftQueueTransaction()
+      throw error
+    }
     drafts.delete(draftId)
-    saveDrafts()
+    try {
+      saveDrafts()
+      finishDraftQueueTransaction()
+    } catch (error) {
+      log.error('Queue item is durable; draft cleanup will be recovered on restart:', error)
+    }
     void queueManager.startQueue()
   })
 
@@ -220,12 +380,25 @@ export function setupJobIpcHandlers(): void {
       await queueManager.validateJobCanTrain(entry.spec)
     }
 
+    beginDraftQueueTransaction({
+      draftIds: specsToEnqueue.map((entry) => entry.draftId),
+      queuedJobIds: specsToEnqueue.map((entry) => entry.spec.id)
+    })
+    try {
+      queueManager.addManyToQueue(specsToEnqueue.map((entry) => entry.spec))
+    } catch (error) {
+      finishDraftQueueTransaction()
+      throw error
+    }
     for (const entry of specsToEnqueue) {
-      queueManager.addToQueue(entry.spec)
       drafts.delete(entry.draftId)
     }
-
-    saveDrafts()
+    try {
+      saveDrafts()
+      finishDraftQueueTransaction()
+    } catch (error) {
+      log.error('Queued jobs are durable; draft cleanup will be recovered on restart:', error)
+    }
     void queueManager.startQueue()
   })
 

--- a/src/main/ipc/logs.ts
+++ b/src/main/ipc/logs.ts
@@ -1,8 +1,8 @@
 import { app, ipcMain } from 'electron'
-import { existsSync, readFileSync } from 'fs'
 import log from 'electron-log/main'
 import { join } from 'path'
 import { getQueueManager } from '../jobs/queueManager'
+import { readLogChunk } from '../logs/logReader'
 
 const userDataPath = app.getPath('userData')
 
@@ -12,18 +12,22 @@ export function setupLogsIpcHandlers(): void {
   ipcMain.handle('logs:getTerminal', async (_event, jobId: string) => {
     const runtime = getQueueManager().getQueue().find((job) => job.jobId === jobId)
     const logPath = runtime?.terminalLogPath || join(userDataPath, 'workspaces', jobId, 'terminal.log')
-    if (existsSync(logPath)) {
-      return readFileSync(logPath, 'utf-8')
-    }
-    return ''
+    return (await readLogChunk(logPath, null)).content
+  })
+
+  ipcMain.handle('logs:getTerminalChunk', async (_event, jobId: string, offset: number | null) => {
+    const runtime = getQueueManager().getQueue().find((job) => job.jobId === jobId)
+    const logPath = runtime?.terminalLogPath || join(userDataPath, 'workspaces', jobId, 'terminal.log')
+    return await readLogChunk(logPath, offset)
   })
 
   ipcMain.handle('logs:getDiagnostics', async () => {
     const diagPath = join(userDataPath, 'logs', 'nam-bot.log')
-    if (existsSync(diagPath)) {
-      return readFileSync(diagPath, 'utf-8')
-    }
-    return 'No diagnostics available'
+    const result = await readLogChunk(diagPath, null, {
+      initialTailBytes: 512 * 1024,
+      maxChunkBytes: 512 * 1024
+    })
+    return result.content || 'No diagnostics available'
   })
 
   log.info('Logs IPC handlers registered')

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -43,10 +43,10 @@ export function setupIpcHandlers(): void {
 
   ipcMain.handle('settings:save', async (_event, settings: AppSettings) => {
     try {
-      saveSettings(settings)
-      cachedSettings = settings
+      const normalizedSettings = saveSettings(settings)
+      cachedSettings = normalizedSettings
       // Keep queue runner in sync with latest settings without requiring restart.
-      getQueueManager().setSettings(settings)
+      getQueueManager().setSettings(normalizedSettings)
       log.info('Settings saved')
     } catch (error) {
       log.error('Failed to save settings:', error)
@@ -138,22 +138,6 @@ export function setupIpcHandlers(): void {
     const result = await dialog.showOpenDialog({
       title: 'Select Directory',
       properties: ['openDirectory', 'createDirectory']
-    })
-    
-    if (result.canceled || result.filePaths.length === 0) {
-      return null
-    }
-    
-    return result.filePaths[0]
-  })
-
-  ipcMain.handle('settings:choosePythonPath', async () => {
-    const result = await dialog.showOpenDialog({
-      title: 'Select Python Executable',
-      properties: ['openFile'],
-      filters: process.platform === 'win32'
-        ? [{ name: 'Python', extensions: ['exe'] }, { name: 'All Files', extensions: ['*'] }]
-        : [{ name: 'All Files', extensions: ['*'] }]
     })
     
     if (result.canceled || result.filePaths.length === 0) {

--- a/src/main/jobs/queueManager.test.ts
+++ b/src/main/jobs/queueManager.test.ts
@@ -75,6 +75,20 @@ function buildJobSpec(overrides: Partial<JobSpec> = {}): JobSpec {
   }
 }
 
+function writeNamModel(filePath: string): void {
+  writeFileSync(
+    filePath,
+    JSON.stringify({
+      version: '0.0.0',
+      architecture: 'WaveNet',
+      config: {},
+      weights: [],
+      metadata: {}
+    }),
+    'utf-8'
+  )
+}
+
 function createQueueManager(): QueueManager {
   const queueManager = new QueueManager()
   queueManager.setSettings(defaultSettings)
@@ -121,7 +135,9 @@ describe('QueueManager A2 diagnostics gate', () => {
     queueManager.addToQueue(buildJobSpec())
     await queueManager.startQueue()
 
-    runNamFullMock.mockImplementation(async (_settings, _args, hooks) => {
+    runNamFullMock.mockImplementation(async (_settings, args, hooks) => {
+      mkdirSync(args.outputRootDir, { recursive: true })
+      writeNamModel(join(args.outputRootDir, 'model.nam'))
       hooks.onStarted(1234)
       hooks.onExit(0)
       return {
@@ -180,7 +196,9 @@ describe('QueueManager A2 diagnostics gate', () => {
       errorMessage: null,
       output: 'NAM_BOT_LATENCY_ANALYSIS={"ok":true}'
     })
-    runNamFullMock.mockImplementation(async (_settings, _args, hooks) => {
+    runNamFullMock.mockImplementation(async (_settings, args, hooks) => {
+      mkdirSync(args.outputRootDir, { recursive: true })
+      writeNamModel(join(args.outputRootDir, 'model.nam'))
       hooks.onStarted(1234)
       hooks.onTerminalData('training started\n')
       hooks.onExit(0)
@@ -259,5 +277,201 @@ describe('QueueManager A2 diagnostics gate', () => {
     expect(existsSync(copiedModelPath)).toBe(true)
     expect(readFileSync(copiedModelPath, 'utf-8')).toContain('WaveNet')
     expect(existsSync(join(outputRootDir, 'A2 Queued Diagnostics Job.nam'))).toBe(true)
+  })
+
+  it('does not publish a partial model after a failed training exit', async () => {
+    const queueManager = createQueueManager()
+    const outputAudioDirectory = join(mockPaths.userDataPath, 'captures')
+    const outputRootDir = join(mockPaths.userDataPath, 'failed-models')
+    mkdirSync(outputAudioDirectory, { recursive: true })
+    mkdirSync(outputRootDir, { recursive: true })
+    queueManager.setKnownNamVersion(defaultSettings, '0.13.0')
+    queueManager.addToQueue(buildJobSpec({
+      copyFinalModelToOutputAudioFolder: true,
+      outputAudioPath: join(outputAudioDirectory, 'output.wav'),
+      outputRootDir
+    }))
+
+    runNamFullMock.mockImplementation(async (_settings, args, hooks) => {
+      writeNamModel(join(args.outputRootDir, 'partial.nam'))
+      hooks.onStarted(1234)
+      hooks.onExit(1)
+      return {
+        cancel: vi.fn(),
+        forceKill: vi.fn(async () => undefined),
+        forceKillSync: vi.fn()
+      }
+    })
+
+    await queueManager.startQueue()
+
+    const [runtime] = queueManager.getQueue()
+    expect(runtime.status).toBe('failed')
+    expect(existsSync(join(outputRootDir, 'partial.nam'))).toBe(true)
+    expect(existsSync(join(outputRootDir, 'A2 Queued Diagnostics Job.nam'))).toBe(false)
+    expect(existsSync(join(outputAudioDirectory, 'A2 Queued Diagnostics Job.nam'))).toBe(false)
+  })
+
+  it('does not bind a new job to a recent artifact in an older run directory', async () => {
+    const queueManager = createQueueManager()
+    const outputRootDir = join(mockPaths.userDataPath, 'shared-models')
+    const olderRunDirectory = join(outputRootDir, '2020-01-01-00-00-00')
+    mkdirSync(olderRunDirectory, { recursive: true })
+    const olderModelPath = join(olderRunDirectory, 'older-model.nam')
+    writeNamModel(olderModelPath)
+    queueManager.setKnownNamVersion(defaultSettings, '0.13.0')
+    queueManager.addToQueue(buildJobSpec({ outputRootDir }))
+
+    runNamFullMock.mockImplementation(async (_settings, _args, hooks) => {
+      hooks.onStarted(1234)
+      hooks.onExit(0)
+      return {
+        cancel: vi.fn(),
+        forceKill: vi.fn(async () => undefined),
+        forceKillSync: vi.fn()
+      }
+    })
+
+    await queueManager.startQueue()
+
+    const [runtime] = queueManager.getQueue()
+    expect(runtime.status).toBe('failed')
+    expect(runtime.errorCategory).toBe('missing_model_artifact')
+    expect(runtime.resolvedRunDirectory).toBeNull()
+    expect(existsSync(olderModelPath)).toBe(true)
+    expect(existsSync(join(olderRunDirectory, 'A2 Queued Diagnostics Job.nam'))).toBe(false)
+  })
+
+  it('does not publish a pre-existing fresh model from a shared output root', async () => {
+    const queueManager = createQueueManager()
+    const outputRootDir = join(mockPaths.userDataPath, 'shared-root-models')
+    mkdirSync(outputRootDir, { recursive: true })
+    const existingModelPath = join(outputRootDir, 'existing-model.nam')
+    writeNamModel(existingModelPath)
+    queueManager.setKnownNamVersion(defaultSettings, '0.13.0')
+    queueManager.addToQueue(buildJobSpec({ outputRootDir }))
+
+    runNamFullMock.mockImplementation(async (_settings, _args, hooks) => {
+      hooks.onStarted(1234)
+      hooks.onExit(0)
+      return {
+        cancel: vi.fn(),
+        forceKill: vi.fn(async () => undefined),
+        forceKillSync: vi.fn()
+      }
+    })
+
+    await queueManager.startQueue()
+
+    const [runtime] = queueManager.getQueue()
+    expect(runtime.status).toBe('failed')
+    expect(runtime.errorCategory).toBe('missing_model_artifact')
+    expect(existsSync(existingModelPath)).toBe(true)
+    expect(existsSync(join(outputRootDir, 'A2 Queued Diagnostics Job.nam'))).toBe(false)
+  })
+
+  it('cancels a job while latency preparation is still running', async () => {
+    const queueManager = createQueueManager()
+    queueManager.setKnownNamVersion(defaultSettings, '0.13.0')
+    const job = buildJobSpec({
+      trainingOverrides: {
+        latencyMode: 'auto',
+        latencySamples: 0
+      }
+    })
+    queueManager.addToQueue(job)
+    analyzeNamLatencyMock.mockImplementation(
+      async (_settings, _inputPath, _outputPath, signal: AbortSignal) =>
+        await new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true })
+        })
+    )
+
+    const queuePromise = queueManager.startQueue()
+    await vi.waitFor(() => {
+      expect(analyzeNamLatencyMock).toHaveBeenCalledTimes(1)
+    })
+    await queueManager.cancelJob(job.id)
+    await queuePromise
+
+    const [runtime] = queueManager.getQueue()
+    expect(runtime.status).toBe('canceled')
+    expect(runtime.errorCategory).toBe('stopped_by_user')
+    expect(runNamFullMock).not.toHaveBeenCalled()
+    expect(queueManager.getCurrentJob()).toBeNull()
+  })
+
+  it('uses one immutable backend settings snapshot for the complete run', async () => {
+    const queueManager = createQueueManager()
+    queueManager.setKnownNamVersion(defaultSettings, '0.13.0')
+    const job = buildJobSpec({
+      outputRootDir: join(mockPaths.userDataPath, 'snapshot-models'),
+      trainingOverrides: {
+        latencyMode: 'auto',
+        latencySamples: 0
+      }
+    })
+    queueManager.addToQueue(job)
+
+    let releaseLatencyAnalysis: () => void = () => undefined
+    analyzeNamLatencyMock.mockImplementation(async () => {
+      await new Promise<void>((resolve) => {
+        releaseLatencyAnalysis = resolve
+      })
+      return {
+        ok: true,
+        recommendedLatency: 12,
+        inputVersion: '3.0.0',
+        strongInputMatch: true,
+        warnings: null,
+        delays: [12],
+        errorMessage: null,
+        output: 'NAM_BOT_LATENCY_ANALYSIS={"ok":true}'
+      }
+    })
+    runNamFullMock.mockImplementation(async (settings, args, hooks) => {
+      expect(settings.environmentName).toBe(defaultSettings.environmentName)
+      mkdirSync(args.outputRootDir, { recursive: true })
+      writeNamModel(join(args.outputRootDir, 'model.nam'))
+      hooks.onStarted(1234)
+      hooks.onExit(0)
+      return {
+        cancel: vi.fn(),
+        forceKill: vi.fn(async () => undefined),
+        forceKillSync: vi.fn()
+      }
+    })
+
+    const queuePromise = queueManager.startQueue()
+    await vi.waitFor(() => {
+      expect(analyzeNamLatencyMock).toHaveBeenCalledTimes(1)
+    })
+    queueManager.setSettings({
+      ...defaultSettings,
+      environmentName: 'different-environment'
+    })
+    releaseLatencyAnalysis()
+    await queuePromise
+
+    expect(runNamFullMock).toHaveBeenCalledTimes(1)
+    expect(queueManager.getQueue()[0]?.status).toBe('succeeded')
+  })
+
+  it('marks workspace setup errors failed and clears the active job', async () => {
+    const invalidWorkspaceRoot = join(mockPaths.userDataPath, 'workspace-file')
+    writeFileSync(invalidWorkspaceRoot, 'not a directory', 'utf-8')
+    const queueManager = new QueueManager()
+    queueManager.setSettings({
+      ...defaultSettings,
+      defaultWorkspaceRoot: invalidWorkspaceRoot
+    })
+    queueManager.addToQueue(buildJobSpec())
+
+    await queueManager.startQueue()
+
+    const [runtime] = queueManager.getQueue()
+    expect(runtime.status).toBe('failed')
+    expect(queueManager.getCurrentJob()).toBeNull()
+    expect(queueManager.isQueueProcessing()).toBe(false)
   })
 })

--- a/src/main/jobs/queueManager.test.ts
+++ b/src/main/jobs/queueManager.test.ts
@@ -142,7 +142,7 @@ describe('QueueManager A2 diagnostics gate', () => {
       hooks.onExit(0)
       return {
         cancel: vi.fn(),
-        forceKill: vi.fn(async () => undefined),
+        forceKill: vi.fn(async () => true),
         forceKillSync: vi.fn()
       }
     })
@@ -204,7 +204,7 @@ describe('QueueManager A2 diagnostics gate', () => {
       hooks.onExit(0)
       return {
         cancel: vi.fn(),
-        forceKill: vi.fn(async () => undefined),
+        forceKill: vi.fn(async () => true),
         forceKillSync: vi.fn()
       }
     })
@@ -230,6 +230,42 @@ describe('QueueManager A2 diagnostics gate', () => {
     expect(terminalLog).toContain('[NAM-BOT] Auto-aligning input/output latency with the NAM analyzer...')
     expect(terminalLog).toContain('[NAM-BOT] Auto-aligned latency using NAM input 3.0.0: 42 samples.')
     expect(terminalLog).toContain('training started')
+  })
+
+  it('coalesces bursts of terminal progress into bounded renderer updates', async () => {
+    const queueManager = createQueueManager()
+    queueManager.setKnownNamVersion(defaultSettings, '0.13.0')
+    queueManager.addToQueue(buildJobSpec())
+    let captureBurstUpdates = false
+    let burstUpdateCount = 0
+    queueManager.on('jobUpdated', () => {
+      if (captureBurstUpdates) {
+        burstUpdateCount += 1
+      }
+    })
+
+    runNamFullMock.mockImplementation(async (_settings, args, hooks) => {
+      hooks.onStarted(1234)
+      captureBurstUpdates = true
+      for (let index = 0; index < 100; index += 1) {
+        hooks.onTerminalData(`progress update ${index}\n`)
+      }
+      await new Promise((resolve) => setTimeout(resolve, 350))
+      captureBurstUpdates = false
+      mkdirSync(args.outputRootDir, { recursive: true })
+      writeNamModel(join(args.outputRootDir, 'model.nam'))
+      hooks.onExit(0)
+      return {
+        cancel: vi.fn(),
+        forceKill: vi.fn(async () => true),
+        forceKillSync: vi.fn()
+      }
+    })
+
+    await queueManager.startQueue()
+
+    expect(burstUpdateCount).toBe(1)
+    expect(queueManager.getQueue()[0]?.status).toBe('succeeded')
   })
 
   it('copies the finalized model beside the output audio when requested', async () => {
@@ -263,7 +299,7 @@ describe('QueueManager A2 diagnostics gate', () => {
       hooks.onExit(0)
       return {
         cancel: vi.fn(),
-        forceKill: vi.fn(async () => undefined),
+        forceKill: vi.fn(async () => true),
         forceKillSync: vi.fn()
       }
     })
@@ -298,7 +334,7 @@ describe('QueueManager A2 diagnostics gate', () => {
       hooks.onExit(1)
       return {
         cancel: vi.fn(),
-        forceKill: vi.fn(async () => undefined),
+        forceKill: vi.fn(async () => true),
         forceKillSync: vi.fn()
       }
     })
@@ -327,7 +363,7 @@ describe('QueueManager A2 diagnostics gate', () => {
       hooks.onExit(0)
       return {
         cancel: vi.fn(),
-        forceKill: vi.fn(async () => undefined),
+        forceKill: vi.fn(async () => true),
         forceKillSync: vi.fn()
       }
     })
@@ -356,7 +392,7 @@ describe('QueueManager A2 diagnostics gate', () => {
       hooks.onExit(0)
       return {
         cancel: vi.fn(),
-        forceKill: vi.fn(async () => undefined),
+        forceKill: vi.fn(async () => true),
         forceKillSync: vi.fn()
       }
     })
@@ -401,6 +437,64 @@ describe('QueueManager A2 diagnostics gate', () => {
     expect(queueManager.getCurrentJob()).toBeNull()
   })
 
+  it('finalizes a force-stopped job even when the PTY never emits an exit event', async () => {
+    const queueManager = createQueueManager()
+    queueManager.setKnownNamVersion(defaultSettings, '0.13.0')
+    const job = buildJobSpec()
+    const forceKill = vi.fn(async () => true)
+    queueManager.addToQueue(job)
+    runNamFullMock.mockImplementation(async (_settings, _args, hooks) => {
+      hooks.onStarted(1234)
+      return {
+        cancel: vi.fn(),
+        forceKill,
+        forceKillSync: vi.fn()
+      }
+    })
+
+    const queuePromise = queueManager.startQueue()
+    await vi.waitFor(() => {
+      expect(queueManager.getCurrentJob()?.status).toBe('running')
+    })
+    await queueManager.forceStopJob(job.id)
+    await queuePromise
+
+    const [runtime] = queueManager.getQueue()
+    expect(forceKill).toHaveBeenCalledTimes(1)
+    expect(runtime.status).toBe('canceled')
+    expect(runtime.errorCategory).toBe('force_stopped')
+    expect(runtime.pid).toBeNull()
+    expect(queueManager.getCurrentJob()).toBeNull()
+  })
+
+  it('reports a terminal failure when process-tree termination cannot be confirmed', async () => {
+    const queueManager = createQueueManager()
+    queueManager.setKnownNamVersion(defaultSettings, '0.13.0')
+    const job = buildJobSpec()
+    queueManager.addToQueue(job)
+    runNamFullMock.mockImplementation(async (_settings, _args, hooks) => {
+      hooks.onStarted(1234)
+      return {
+        cancel: vi.fn(),
+        forceKill: vi.fn(async () => false),
+        forceKillSync: vi.fn()
+      }
+    })
+
+    const queuePromise = queueManager.startQueue()
+    await vi.waitFor(() => {
+      expect(queueManager.getCurrentJob()?.status).toBe('running')
+    })
+    await queueManager.forceStopJob(job.id)
+    await queuePromise
+
+    const [runtime] = queueManager.getQueue()
+    expect(runtime.status).toBe('failed')
+    expect(runtime.errorCategory).toBe('force_stop_failed')
+    expect(runtime.userMessages.at(-1)).toContain('Task Manager')
+    expect(queueManager.getCurrentJob()).toBeNull()
+  })
+
   it('uses one immutable backend settings snapshot for the complete run', async () => {
     const queueManager = createQueueManager()
     queueManager.setKnownNamVersion(defaultSettings, '0.13.0')
@@ -437,7 +531,7 @@ describe('QueueManager A2 diagnostics gate', () => {
       hooks.onExit(0)
       return {
         cancel: vi.fn(),
-        forceKill: vi.fn(async () => undefined),
+        forceKill: vi.fn(async () => true),
         forceKillSync: vi.fn()
       }
     })

--- a/src/main/jobs/queueManager.ts
+++ b/src/main/jobs/queueManager.ts
@@ -43,6 +43,11 @@ import {
 } from '../types/jobs'
 import { AppSettings } from '../types'
 import {
+  atomicWriteFileSync,
+  atomicWriteJsonSync,
+  readJsonWithBackupSync
+} from '../persistence/atomicFile'
+import {
   buildUpdatedNamModelMetadata,
   hasNamModelMetadataUpdates,
   type ConfirmedNamTrainingMetadata,
@@ -74,6 +79,14 @@ const OSC_PATTERN = /\u001b\][^\u0007]*(?:\u0007|\u001b\\)/g
 const CONTROL_PATTERN = /[\u0000-\u0008\u000b\u000c\u000e-\u001a\u007f]/g
 const LATENCY_ALIGNMENT_STATUSES: JobLatencyAlignmentStatus[] = ['manual', 'auto_pending', 'auto_applied', 'auto_skipped', 'auto_failed']
 type RunJobResult = 'completed' | 'blocked'
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
+function getRuntimeModelFilePath(runtime: JobRuntimeState): string | null {
+  return runtime.checkpointSummary?.modelFilePath ?? null
+}
 
 interface KnownNamVersion {
   settingsKey: string
@@ -490,13 +503,48 @@ function parseCheckpointFile(
   return null
 }
 
-function readPackedBestSubmodels(outputRunDirectory: string): JobPackedSubmodelCheckpointSummary[] {
+function getArtifactFingerprint(filePath: string): string {
+  const stats = statSync(filePath)
+  return `${stats.mtimeMs}:${stats.size}`
+}
+
+function isTrainingArtifactPath(filePath: string): boolean {
+  const normalized = filePath.toLowerCase()
+  return normalized.endsWith('.nam')
+    || normalized.endsWith('.ckpt')
+    || normalized.endsWith('comparison.png')
+    || normalized.endsWith('packed_best.json')
+}
+
+function snapshotTrainingArtifacts(outputRootDirectory: string): Map<string, string> {
+  const snapshot = new Map<string, string>()
+  for (const filePath of walkTrainingArtifacts(outputRootDirectory, 4)) {
+    if (!isTrainingArtifactPath(filePath)) {
+      continue
+    }
+    try {
+      snapshot.set(filePath, getArtifactFingerprint(filePath))
+    } catch (error) {
+      log.warn('Failed to snapshot pre-existing training artifact:', filePath, error)
+    }
+  }
+  return snapshot
+}
+
+function readPackedBestSubmodels(
+  outputRunDirectory: string,
+  artifactBaseline?: Map<string, string>
+): JobPackedSubmodelCheckpointSummary[] {
   const metadataPath = join(outputRunDirectory, 'packed_best.json')
   if (!existsSync(metadataPath)) {
     return []
   }
 
   try {
+    if (artifactBaseline?.get(metadataPath) === getArtifactFingerprint(metadataPath)) {
+      return []
+    }
+
     const parsed = JSON.parse(readFileSync(metadataPath, 'utf-8')) as unknown
     if (!isRecord(parsed) || !Array.isArray(parsed.submodels)) {
       return []
@@ -589,7 +637,8 @@ function getFileModifiedAt(filePath: string): number {
 function buildCheckpointSummary(
   outputRunDirectory: string,
   startedAt: string | undefined,
-  usesPackedA2: boolean
+  usesPackedA2: boolean,
+  artifactBaseline?: Map<string, string>
 ): JobCheckpointSummary | null {
   if (!existsSync(outputRunDirectory)) {
     return null
@@ -598,6 +647,9 @@ function buildCheckpointSummary(
   const startedAtMs = startedAt ? Date.parse(startedAt) : 0
   const files = walkTrainingArtifacts(outputRunDirectory, 4).filter((filePath) => {
     try {
+      if (artifactBaseline?.get(filePath) === getArtifactFingerprint(filePath)) {
+        return false
+      }
       return getFileModifiedAt(filePath) >= startedAtMs - 15_000
     } catch (error) {
       log.warn('Failed to stat training artifact:', filePath, error)
@@ -612,7 +664,7 @@ function buildCheckpointSummary(
   let bestCheckpointPath: string | null = null
   let modelFilePath: string | null = null
   let comparisonPlotPath: string | null = null
-  const packedSubmodels = readPackedBestSubmodels(outputRunDirectory)
+  const packedSubmodels = readPackedBestSubmodels(outputRunDirectory, artifactBaseline)
   const primaryPackedSubmodel = usesPackedA2 ? selectPrimaryPackedSubmodel(packedSubmodels) : null
 
   for (const filePath of files) {
@@ -909,6 +961,8 @@ export class QueueManager extends EventEmitter {
   private settings: AppSettings | null = null
   private isRunning: boolean = false
   private activeController: TrainingProcessController | null = null
+  private activePreparationAbortController: AbortController | null = null
+  private artifactBaselines: Map<string, Map<string, string>> = new Map()
   private outputPollTimer: NodeJS.Timeout | null = null
   private knownNamVersion: KnownNamVersion | null = null
 
@@ -957,7 +1011,11 @@ export class QueueManager extends EventEmitter {
       return
     }
 
-    copyFileSync(runtime.terminalLogPath, runtime.publishedTerminalLogPath)
+    try {
+      copyFileSync(runtime.terminalLogPath, runtime.publishedTerminalLogPath)
+    } catch (error) {
+      log.warn('Failed to synchronize published terminal log:', error)
+    }
   }
 
   private processTerminalChunk(
@@ -1060,7 +1118,7 @@ export class QueueManager extends EventEmitter {
         confirmedTrainingMetadata,
         exportDate
       })
-      writeFileSync(modelPath, JSON.stringify(parsed), 'utf-8')
+      atomicWriteFileSync(modelPath, JSON.stringify(parsed), { backup: false })
     } catch (error) {
       this.appendUserMessage(runtime, `Training completed, but writing NAM metadata failed: ${String(error)}`)
     }
@@ -1117,7 +1175,7 @@ export class QueueManager extends EventEmitter {
       if (!existsSync(queuePath)) {
         return
       }
-      const parsed = JSON.parse(readFileSync(queuePath, 'utf-8')) as unknown
+      const parsed = readJsonWithBackupSync(queuePath)
       if (!Array.isArray(parsed)) {
         this.queue = []
         return
@@ -1152,11 +1210,7 @@ export class QueueManager extends EventEmitter {
   }
 
   private saveQueue(): void {
-    try {
-      writeFileSync(queuePath, JSON.stringify(this.queue, null, 2), 'utf-8')
-    } catch (error) {
-      log.error('Failed to save queue:', error)
-    }
+    atomicWriteJsonSync(queuePath, this.queue)
   }
 
   private stopOutputPolling(): void {
@@ -1207,10 +1261,17 @@ export class QueueManager extends EventEmitter {
       changed = true
     }
 
-    const artifactDirectory = runtime.resolvedRunDirectory ?? runtime.outputRootDir
+    const artifactDirectory = runtime.resolvedRunDirectory
     const previousSummary = runtime.checkpointSummary
     const preset = getTrainingPresetById(runtime.frozenJob.presetId)
-    const nextSummary = buildCheckpointSummary(artifactDirectory, runtime.startedAt, isA2TrainingPreset(preset)) ?? undefined
+    const nextSummary = artifactDirectory
+      ? buildCheckpointSummary(
+        artifactDirectory,
+        runtime.startedAt,
+        isA2TrainingPreset(preset),
+        this.artifactBaselines.get(runtime.jobId)
+      ) ?? undefined
+      : undefined
 
     if (!checkpointSummariesEqual(previousSummary, nextSummary)) {
       runtime.checkpointSummary = nextSummary
@@ -1273,13 +1334,13 @@ export class QueueManager extends EventEmitter {
       modelConfig: string
       learningConfig: string
     },
-    runtime: JobRuntimeState
+    runtime: JobRuntimeState,
+    settings: AppSettings,
+    signal: AbortSignal
   ): Promise<void> {
-    if (!this.settings) {
-      return
-    }
-
-    const torchRuntime = await inspectTorchRuntime(this.settings)
+    signal.throwIfAborted()
+    const torchRuntime = await inspectTorchRuntime(settings, signal)
+    signal.throwIfAborted()
     const acceleratorRequested = chooseAccelerator(torchRuntime)
     runtime.deviceSummary = buildDeviceSummary(torchRuntime, acceleratorRequested)
 
@@ -1479,17 +1540,13 @@ export class QueueManager extends EventEmitter {
     }
   }
 
-  private async assertTrainingRequirements(jobSpec: JobSpec): Promise<void> {
-    if (!this.settings) {
-      throw new Error('Cannot validate training requirements because settings are not loaded.')
-    }
-
+  private async assertTrainingRequirements(jobSpec: JobSpec, settings: AppSettings): Promise<void> {
     const preset = getTrainingPresetById(jobSpec.presetId)
     if (!isA2TrainingPreset(preset)) {
       return
     }
 
-    const settingsKey = buildBackendSettingsKey(this.settings)
+    const settingsKey = buildBackendSettingsKey(settings)
     const installedVersion = this.knownNamVersion?.settingsKey === settingsKey
       ? this.knownNamVersion.version
       : null
@@ -1505,8 +1562,12 @@ export class QueueManager extends EventEmitter {
   }
 
   async validateJobCanTrain(jobSpec: JobSpec): Promise<void> {
+    if (!this.settings) {
+      throw new Error('Cannot validate training requirements because settings are not loaded.')
+    }
+
     try {
-      await this.assertTrainingRequirements(jobSpec)
+      await this.assertTrainingRequirements(jobSpec, { ...this.settings })
     } catch (error) {
       if (isA2DiagnosticsPendingError(error)) {
         return
@@ -1527,8 +1588,8 @@ export class QueueManager extends EventEmitter {
     return this.isRunning
   }
 
-  addToQueue(jobSpec: JobSpec): JobRuntimeState {
-    const runtime: JobRuntimeState = {
+  private createQueuedRuntime(jobSpec: JobSpec): JobRuntimeState {
+    return {
       jobId: jobSpec.id,
       jobName: jobSpec.name,
       status: 'queued',
@@ -1558,10 +1619,33 @@ export class QueueManager extends EventEmitter {
         latestStructuredLine: 'Waiting in queue'
       }
     }
+  }
+
+  addToQueue(jobSpec: JobSpec): JobRuntimeState {
+    const runtime = this.createQueuedRuntime(jobSpec)
     this.queue.push(runtime)
-    this.emitQueueUpdate()
+    try {
+      this.emitQueueUpdate()
+    } catch (error) {
+      this.queue.pop()
+      throw error
+    }
     log.info('Job added to queue:', jobSpec.id)
     return runtime
+  }
+
+  addManyToQueue(jobSpecs: JobSpec[]): JobRuntimeState[] {
+    const runtimes = jobSpecs.map((jobSpec) => this.createQueuedRuntime(jobSpec))
+    const previousQueue = this.queue
+    this.queue = [...previousQueue, ...runtimes]
+    try {
+      this.emitQueueUpdate()
+    } catch (error) {
+      this.queue = previousQueue
+      throw error
+    }
+    log.info('Jobs added to queue:', runtimes.map((runtime) => runtime.jobId))
+    return runtimes
   }
 
   removeQueueItem(jobId: string): void {
@@ -1584,9 +1668,17 @@ export class QueueManager extends EventEmitter {
       return null
     }
 
+    const previousBatchId = runtime.frozenJob.batchId
+    const previousBatchSourceName = runtime.frozenJob.batchSourceName
     runtime.frozenJob.batchId = batchId
     runtime.frozenJob.batchSourceName = batchSourceName
-    this.emitQueueUpdate()
+    try {
+      this.emitQueueUpdate()
+    } catch (error) {
+      runtime.frozenJob.batchId = previousBatchId
+      runtime.frozenJob.batchSourceName = previousBatchSourceName
+      throw error
+    }
     return runtime
   }
 
@@ -1667,8 +1759,12 @@ export class QueueManager extends EventEmitter {
         runtime.plannedEpochs = jobSpec.trainingOverrides.epochs ?? null
         runtime.outputRootDir = jobSpec.outputRootDir
         this.currentJob = runtime
-        const result = await this.runJob(jobSpec, runtime)
-        this.currentJob = null
+        let result: RunJobResult
+        try {
+          result = await this.runJob(jobSpec, runtime)
+        } finally {
+          this.currentJob = null
+        }
         if (result === 'blocked') {
           break
         }
@@ -1682,10 +1778,20 @@ export class QueueManager extends EventEmitter {
   }
 
   private async runJob(jobSpec: JobSpec, runtime: JobRuntimeState): Promise<RunJobResult> {
-    const workspaceId = uuidv4()
-    const workspaceRoot = resolveWorkspaceRoot(this.settings)
-    const workspaceDir = join(workspaceRoot, workspaceId)
-    const terminalPath = join(workspaceDir, 'terminal.log')
+    const runSettings = this.settings ? { ...this.settings } : null
+    const preparationAbortController = new AbortController()
+    this.activePreparationAbortController = preparationAbortController
+
+    try {
+      if (!runSettings) {
+        throw new Error('Cannot start training because settings are not loaded.')
+      }
+
+      const workspaceId = uuidv4()
+      const workspaceRoot = resolveWorkspaceRoot(runSettings)
+      const workspaceDir = join(workspaceRoot, workspaceId)
+      const terminalPath = join(workspaceDir, 'terminal.log')
+      this.artifactBaselines.set(jobSpec.id, snapshotTrainingArtifacts(jobSpec.outputRootDir))
 
     if (!existsSync(workspaceDir)) {
       mkdirSync(workspaceDir, { recursive: true })
@@ -1752,7 +1858,7 @@ export class QueueManager extends EventEmitter {
         log.warn('Failed to refresh final training artifacts:', error)
       }
 
-      if (runtime.status === 'succeeded' && this.settings?.autoOpenResultsFolder && runtime.resolvedRunDirectory) {
+      if (runtime.status === 'succeeded' && runSettings.autoOpenResultsFolder && runtime.resolvedRunDirectory) {
         shell.openPath(runtime.resolvedRunDirectory)
       }
     }
@@ -1765,7 +1871,7 @@ export class QueueManager extends EventEmitter {
       let controller: TrainingProcessController | null = null
 
       controller = await runNamFull(
-        this.settings!,
+        runSettings,
         {
           dataConfigPath: configPaths.dataConfig,
           modelConfigPath: configPaths.modelConfig,
@@ -1844,15 +1950,16 @@ export class QueueManager extends EventEmitter {
             this.syncPublishedTerminalLog(runtime)
             this.emitJobUpdate(runtime)
           }
-        }
+        },
+        preparationAbortController.signal
       )
 
       this.activeController = controller
       await waitForCompletion()
     }
 
-    try {
-      await this.assertTrainingRequirements(jobSpec)
+      await this.assertTrainingRequirements(jobSpec, runSettings)
+      preparationAbortController.signal.throwIfAborted()
       const preset = getTrainingPresetById(jobSpec.presetId)
       const latencyLocked = preset.lockedJobFields.includes('latencySamples')
       let jobSpecForConfig = jobSpec
@@ -1872,7 +1979,13 @@ export class QueueManager extends EventEmitter {
         }
         this.emitJobUpdate(runtime)
 
-        const latencyAnalysis = await analyzeNamLatency(this.settings!, jobSpec.inputAudioPath, jobSpec.outputAudioPath)
+        const latencyAnalysis = await analyzeNamLatency(
+          runSettings,
+          jobSpec.inputAudioPath,
+          jobSpec.outputAudioPath,
+          preparationAbortController.signal
+        )
+        preparationAbortController.signal.throwIfAborted()
         if (!latencyAnalysis.ok || latencyAnalysis.recommendedLatency == null) {
           const failureReason = latencyAnalysis.errorMessage ?? 'NAM could not calculate a recommended delay. Switch latency to Manual and enter a value, or use a recognized NAM standard input file.'
           const failureMessage = `Auto latency alignment failed: ${failureReason}`
@@ -1931,14 +2044,36 @@ export class QueueManager extends EventEmitter {
       this.appendUserMessage(runtime, 'Generating NAM training configuration files...', { persistToTerminalLog: true })
       const configPaths = buildJobConfigs(jobSpecForConfig, workspaceDir, preset)
       runtime.generatedConfigPaths = configPaths
-      await this.prepareLearningConfigForRuntime(configPaths, runtime)
+      await this.prepareLearningConfigForRuntime(
+        configPaths,
+        runtime,
+        runSettings,
+        preparationAbortController.signal
+      )
 
       this.appendUserMessage(runtime, 'Starting NAM training...', { persistToTerminalLog: true })
       this.appendUserMessage(runtime, `Training output root: ${jobSpec.outputRootDir}`, { persistToTerminalLog: true })
       this.emitJobUpdate(runtime)
 
       await runTrainingProcess(configPaths)
-      await finalizeSuccessfulRun()
+      const trainingSucceeded = (): boolean => runtime.status === 'succeeded'
+      if (trainingSucceeded()) {
+        this.refreshTrainingArtifacts(runtime)
+        if (!getRuntimeModelFilePath(runtime)) {
+          runtime.status = 'failed'
+          runtime.errorCategory = 'missing_model_artifact'
+          this.appendUserMessage(
+            runtime,
+            'Training exited successfully, but NAM did not produce a final model file. The run has been marked failed so a checkpoint is not published as a completed model.'
+          )
+          this.emitJobUpdate(runtime)
+        } else {
+          await finalizeSuccessfulRun()
+        }
+      } else {
+        this.refreshTrainingArtifacts(runtime)
+        this.syncPublishedTerminalLog(runtime)
+      }
       return 'completed'
     } catch (error) {
       if (isA2DiagnosticsPendingError(error)) {
@@ -1947,21 +2082,29 @@ export class QueueManager extends EventEmitter {
         return 'blocked'
       }
 
-      runtime.status = 'failed'
-      runtime.errorCategory = 'unknown_error'
+      const wasCanceled = preparationAbortController.signal.aborted || isAbortError(error) || runtime.stopMode !== null
+      runtime.status = wasCanceled ? 'canceled' : 'failed'
+      runtime.errorCategory = wasCanceled ? 'stopped_by_user' : runtime.errorCategory ?? 'unknown_error'
       runtime.finishedAt = new Date().toISOString()
-      this.appendUserMessage(runtime, `Training setup failed: ${String(error)}`)
+      this.appendUserMessage(
+        runtime,
+        wasCanceled ? 'Training preparation was canceled.' : `Training setup failed: ${String(error)}`
+      )
       this.emitJobUpdate(runtime)
       return 'completed'
     } finally {
       this.activeController = null
+      if (this.activePreparationAbortController === preparationAbortController) {
+        this.activePreparationAbortController = null
+      }
+      this.artifactBaselines.delete(runtime.jobId)
       this.stopOutputPolling()
       this.syncPublishedTerminalLog(runtime)
     }
   }
 
   async cancelJob(jobId: string): Promise<void> {
-    if (!this.currentJob || this.currentJob.jobId !== jobId || !this.activeController) {
+    if (!this.currentJob || this.currentJob.jobId !== jobId) {
       return
     }
 
@@ -1970,7 +2113,11 @@ export class QueueManager extends EventEmitter {
     this.currentJob.stopMode = 'graceful'
     this.appendUserMessage(this.currentJob, 'Stop requested. NAM-BOT is asking the trainer to stop cleanly.')
     this.emitJobUpdate(this.currentJob)
-    this.activeController.cancel()
+    if (this.activeController) {
+      this.activeController.cancel()
+    } else {
+      this.activePreparationAbortController?.abort()
+    }
 
     // Watchdog: escalate to force kill if the process doesn't exit within 15 seconds
     const watchdogJobId = jobId
@@ -1984,7 +2131,7 @@ export class QueueManager extends EventEmitter {
   }
 
   async forceStopJob(jobId: string): Promise<void> {
-    if (!this.currentJob || this.currentJob.jobId !== jobId || !this.activeController) {
+    if (!this.currentJob || this.currentJob.jobId !== jobId) {
       return
     }
 
@@ -1993,7 +2140,11 @@ export class QueueManager extends EventEmitter {
     this.currentJob.stopMode = 'force'
     this.appendUserMessage(this.currentJob, 'Force stop requested. NAM-BOT is killing the full training process tree.')
     this.emitJobUpdate(this.currentJob)
-    await this.activeController.forceKill()
+    if (this.activeController) {
+      await this.activeController.forceKill()
+    } else {
+      this.activePreparationAbortController?.abort()
+    }
   }
 
   retryJob(jobId: string): JobRuntimeState | null {
@@ -2064,7 +2215,7 @@ export class QueueManager extends EventEmitter {
   }
 
   shutdownSync(reason: string): void {
-    if (!this.currentJob || !this.activeController) {
+    if (!this.currentJob) {
       return
     }
 
@@ -2077,8 +2228,13 @@ export class QueueManager extends EventEmitter {
     this.currentJob.finishedAt = new Date().toISOString()
     this.currentJob.pid = null
     this.stopOutputPolling()
-    this.activeController.forceKillSync()
+    if (this.activeController) {
+      this.activeController.forceKillSync()
+    } else {
+      this.activePreparationAbortController?.abort()
+    }
     this.activeController = null
+    this.activePreparationAbortController = null
     this.saveQueue()
   }
 }

--- a/src/main/jobs/queueManager.ts
+++ b/src/main/jobs/queueManager.ts
@@ -61,6 +61,8 @@ const workspacesPath = join(userDataPath, 'workspaces')
 const ACTIVE_JOB_STATUSES: JobStatus[] = ['preparing', 'running', 'stopping']
 const QUEUED_JOB_STATUSES: JobStatus[] = ['queued', 'validating']
 const FINISHED_JOB_STATUSES: JobStatus[] = ['succeeded', 'failed', 'canceled']
+const PROGRESS_BROADCAST_INTERVAL_MS = 250
+const PROGRESS_PERSIST_INTERVAL_MS = 1000
 const NUMERIC_TOKEN_PATTERN = '[+-]?\\d+(?:\\.\\d+)?(?:e[+-]?\\d+)?'
 const BEST_CHECKPOINT_PATTERN = new RegExp(
   `^(\\d{4})_(\\d+)_(${NUMERIC_TOKEN_PATTERN})_(${NUMERIC_TOKEN_PATTERN})\\.ckpt$`,
@@ -163,8 +165,7 @@ function buildBackendSettingsKey(settings: AppSettings): string {
     condaExecutablePath: settings.condaExecutablePath,
     backendMode: settings.backendMode,
     environmentName: settings.environmentName,
-    environmentPrefixPath: settings.environmentPrefixPath,
-    pythonExecutablePath: settings.pythonExecutablePath
+    environmentPrefixPath: settings.environmentPrefixPath
   })
 }
 
@@ -964,6 +965,8 @@ export class QueueManager extends EventEmitter {
   private activePreparationAbortController: AbortController | null = null
   private artifactBaselines: Map<string, Map<string, string>> = new Map()
   private outputPollTimer: NodeJS.Timeout | null = null
+  private progressBroadcastTimers: Map<string, NodeJS.Timeout> = new Map()
+  private progressPersistenceTimer: NodeJS.Timeout | null = null
   private knownNamVersion: KnownNamVersion | null = null
 
   private appendTerminalAnnotation(runtime: JobRuntimeState, message: string): void {
@@ -1474,12 +1477,60 @@ export class QueueManager extends EventEmitter {
     return true
   }
 
+  private clearScheduledProgressUpdate(jobId: string): void {
+    const timer = this.progressBroadcastTimers.get(jobId)
+    if (timer) {
+      clearTimeout(timer)
+      this.progressBroadcastTimers.delete(jobId)
+    }
+  }
+
+  private clearAllScheduledProgressUpdates(): void {
+    for (const timer of this.progressBroadcastTimers.values()) {
+      clearTimeout(timer)
+    }
+    this.progressBroadcastTimers.clear()
+    if (this.progressPersistenceTimer) {
+      clearTimeout(this.progressPersistenceTimer)
+      this.progressPersistenceTimer = null
+    }
+  }
+
+  private scheduleProgressUpdate(runtime: JobRuntimeState): void {
+    if (!this.progressBroadcastTimers.has(runtime.jobId)) {
+      const broadcastTimer = setTimeout(() => {
+        this.progressBroadcastTimers.delete(runtime.jobId)
+        if (this.queue.includes(runtime)) {
+          this.emit('jobUpdated', runtime)
+        }
+      }, PROGRESS_BROADCAST_INTERVAL_MS)
+      this.progressBroadcastTimers.set(runtime.jobId, broadcastTimer)
+    }
+
+    if (!this.progressPersistenceTimer) {
+      this.progressPersistenceTimer = setTimeout(() => {
+        this.progressPersistenceTimer = null
+        try {
+          this.saveQueue()
+        } catch (error) {
+          log.error('Failed to persist throttled training progress:', error)
+        }
+      }, PROGRESS_PERSIST_INTERVAL_MS)
+    }
+  }
+
   private emitQueueUpdate(): void {
+    this.clearAllScheduledProgressUpdates()
     this.saveQueue()
     this.emit('queueUpdated', this.getQueue())
   }
 
   private emitJobUpdate(runtime: JobRuntimeState): void {
+    this.clearScheduledProgressUpdate(runtime.jobId)
+    if (this.progressPersistenceTimer) {
+      clearTimeout(this.progressPersistenceTimer)
+      this.progressPersistenceTimer = null
+    }
     this.saveQueue()
     this.emit('jobUpdated', runtime)
   }
@@ -1889,7 +1940,7 @@ export class QueueManager extends EventEmitter {
               changed = this.updateLatestLogLine(runtime, line) || changed
             }
             if (changed) {
-              this.emitJobUpdate(runtime)
+              this.scheduleProgressUpdate(runtime)
             }
           },
           onStarted: (pid) => {
@@ -2098,6 +2149,7 @@ export class QueueManager extends EventEmitter {
         this.activePreparationAbortController = null
       }
       this.artifactBaselines.delete(runtime.jobId)
+      this.clearScheduledProgressUpdate(runtime.jobId)
       this.stopOutputPolling()
       this.syncPublishedTerminalLog(runtime)
     }
@@ -2140,11 +2192,35 @@ export class QueueManager extends EventEmitter {
     this.currentJob.stopMode = 'force'
     this.appendUserMessage(this.currentJob, 'Force stop requested. NAM-BOT is killing the full training process tree.')
     this.emitJobUpdate(this.currentJob)
+    let terminationConfirmed = true
     if (this.activeController) {
-      await this.activeController.forceKill()
+      try {
+        terminationConfirmed = await this.activeController.forceKill()
+      } catch (error) {
+        terminationConfirmed = false
+        log.error(`Force stop failed for job ${jobId}:`, error)
+      }
     } else {
       this.activePreparationAbortController?.abort()
     }
+
+    if (!this.currentJob || this.currentJob.jobId !== jobId || this.currentJob.status !== 'stopping') {
+      return
+    }
+
+    this.currentJob.status = terminationConfirmed ? 'canceled' : 'failed'
+    this.currentJob.finishedAt = new Date().toISOString()
+    this.currentJob.pid = null
+    this.currentJob.errorCategory = terminationConfirmed ? 'force_stopped' : 'force_stop_failed'
+    this.appendUserMessage(
+      this.currentJob,
+      terminationConfirmed
+        ? 'The training process tree was force-stopped.'
+        : 'NAM-BOT could not confirm that the training process tree was terminated. Check Task Manager before starting another training job.'
+    )
+    this.activeController = null
+    this.stopOutputPolling()
+    this.emitJobUpdate(this.currentJob)
   }
 
   retryJob(jobId: string): JobRuntimeState | null {
@@ -2235,6 +2311,7 @@ export class QueueManager extends EventEmitter {
     }
     this.activeController = null
     this.activePreparationAbortController = null
+    this.clearAllScheduledProgressUpdates()
     this.saveQueue()
   }
 }

--- a/src/main/logs/logReader.test.ts
+++ b/src/main/logs/logReader.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { readLogChunk } from './logReader'
+
+const temporaryDirectories: string[] = []
+
+function createLog(contents: string): string {
+  const directory = mkdtempSync(join(tmpdir(), 'nam-bot-log-reader-'))
+  temporaryDirectories.push(directory)
+  const filePath = join(directory, 'terminal.log')
+  writeFileSync(filePath, contents, 'utf-8')
+  return filePath
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('readLogChunk', () => {
+  it('returns only an initial bounded tail for a large log', async () => {
+    const filePath = createLog('first line\nsecond line\nthird line\n')
+    const result = await readLogChunk(filePath, null, { initialTailBytes: 24, maxChunkBytes: 24 })
+
+    expect(result.reset).toBe(true)
+    expect(result.truncated).toBe(true)
+    expect(result.content).toContain('[Earlier log output omitted]')
+    expect(result.content).toContain('third line')
+  })
+
+  it('returns the complete initial tail even when incremental chunks are smaller', async () => {
+    const filePath = createLog('first line\nsecond line\nthird line\n')
+    const result = await readLogChunk(filePath, null, { initialTailBytes: 24, maxChunkBytes: 5 })
+
+    expect(result.nextOffset).toBe(Buffer.byteLength('first line\nsecond line\nthird line\n'))
+    expect(result.content).toContain('third line')
+  })
+
+  it('reads only bytes appended after the previous offset', async () => {
+    const filePath = createLog('first\n')
+    const first = await readLogChunk(filePath, null)
+    writeFileSync(filePath, 'first\nsecond\n', 'utf-8')
+    const second = await readLogChunk(filePath, first.nextOffset)
+
+    expect(second.reset).toBe(false)
+    expect(second.content).toBe('second\n')
+  })
+
+  it('resets safely when a log is replaced with a shorter file', async () => {
+    const filePath = createLog('a much longer original log\n')
+    const first = await readLogChunk(filePath, null)
+    writeFileSync(filePath, 'new\n', 'utf-8')
+    const second = await readLogChunk(filePath, first.nextOffset)
+
+    expect(second.reset).toBe(true)
+    expect(second.content).toBe('new\n')
+    expect(second.nextOffset).toBe(4)
+  })
+})

--- a/src/main/logs/logReader.ts
+++ b/src/main/logs/logReader.ts
@@ -1,0 +1,79 @@
+import { open, stat } from 'fs/promises'
+
+import type { LogChunk } from '../../shared/logs'
+
+const DEFAULT_INITIAL_TAIL_BYTES = 256 * 1024
+const DEFAULT_INCREMENTAL_CHUNK_BYTES = 128 * 1024
+
+interface LogReadOptions {
+  initialTailBytes?: number
+  maxChunkBytes?: number
+}
+
+function buildMissingLogChunk(): LogChunk {
+  return {
+    content: '',
+    nextOffset: 0,
+    reset: true,
+    truncated: false
+  }
+}
+
+export async function readLogChunk(
+  filePath: string,
+  requestedOffset: number | null,
+  options?: LogReadOptions
+): Promise<LogChunk> {
+  let fileSize: number
+  try {
+    fileSize = (await stat(filePath)).size
+  } catch {
+    return buildMissingLogChunk()
+  }
+
+  const initialTailBytes = options?.initialTailBytes ?? DEFAULT_INITIAL_TAIL_BYTES
+  const maxChunkBytes = options?.maxChunkBytes ?? DEFAULT_INCREMENTAL_CHUNK_BYTES
+  const hasValidOffset = requestedOffset != null
+    && Number.isSafeInteger(requestedOffset)
+    && requestedOffset >= 0
+    && requestedOffset <= fileSize
+  const reset = !hasValidOffset
+  const startOffset = hasValidOffset
+    ? requestedOffset
+    : Math.max(0, fileSize - initialTailBytes)
+  const truncated = reset && startOffset > 0
+  const availableBytes = Math.max(0, fileSize - startOffset)
+  const bytesToRead = Math.min(availableBytes, reset ? initialTailBytes : maxChunkBytes)
+
+  if (bytesToRead === 0) {
+    return {
+      content: '',
+      nextOffset: startOffset,
+      reset,
+      truncated
+    }
+  }
+
+  const handle = await open(filePath, 'r')
+  try {
+    const buffer = Buffer.alloc(bytesToRead)
+    const { bytesRead } = await handle.read(buffer, 0, bytesToRead, startOffset)
+    let content = buffer.subarray(0, bytesRead).toString('utf-8')
+    if (truncated) {
+      const firstLineBreak = content.indexOf('\n')
+      if (firstLineBreak >= 0) {
+        content = content.slice(firstLineBreak + 1)
+      }
+      content = `[Earlier log output omitted]\n${content}`
+    }
+
+    return {
+      content,
+      nextOffset: startOffset + bytesRead,
+      reset,
+      truncated
+    }
+  } finally {
+    await handle.close()
+  }
+}

--- a/src/main/persistence/atomicFile.test.ts
+++ b/src/main/persistence/atomicFile.test.ts
@@ -1,0 +1,42 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { atomicWriteFileSync, atomicWriteJsonSync, readJsonWithBackupSync } from './atomicFile'
+
+const temporaryDirectories: string[] = []
+
+function createTemporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), 'nam-bot-atomic-file-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('atomic file persistence', () => {
+  it('replaces a file while retaining the prior version as a backup', () => {
+    const targetPath = join(createTemporaryDirectory(), 'settings.json')
+
+    atomicWriteFileSync(targetPath, 'first')
+    atomicWriteFileSync(targetPath, 'second')
+
+    expect(readFileSync(targetPath, 'utf-8')).toBe('second')
+    expect(readFileSync(`${targetPath}.bak`, 'utf-8')).toBe('first')
+  })
+
+  it('recovers JSON from the backup when the primary file is truncated', () => {
+    const targetPath = join(createTemporaryDirectory(), 'queue.json')
+    atomicWriteJsonSync(targetPath, [{ id: 'first' }])
+    atomicWriteJsonSync(targetPath, [{ id: 'second' }])
+    writeFileSync(targetPath, '{', 'utf-8')
+
+    expect(readJsonWithBackupSync(targetPath)).toEqual([{ id: 'first' }])
+    expect(existsSync(`${targetPath}.bak`)).toBe(true)
+  })
+})

--- a/src/main/persistence/atomicFile.ts
+++ b/src/main/persistence/atomicFile.ts
@@ -1,0 +1,73 @@
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from 'fs'
+import { dirname } from 'path'
+import { randomUUID } from 'crypto'
+
+interface AtomicWriteOptions {
+  backup?: boolean
+}
+
+function writeTemporaryFile(targetPath: string, contents: string): string {
+  const temporaryPath = `${targetPath}.${process.pid}.${randomUUID()}.tmp`
+  const descriptor = openSync(temporaryPath, 'wx')
+  try {
+    writeFileSync(descriptor, contents, 'utf-8')
+    fsyncSync(descriptor)
+  } finally {
+    closeSync(descriptor)
+  }
+  return temporaryPath
+}
+
+export function atomicWriteFileSync(
+  targetPath: string,
+  contents: string,
+  options?: AtomicWriteOptions
+): void {
+  mkdirSync(dirname(targetPath), { recursive: true })
+  let temporaryPath: string | null = writeTemporaryFile(targetPath, contents)
+
+  try {
+    if (options?.backup !== false && existsSync(targetPath)) {
+      const backupPath = `${targetPath}.bak`
+      const backupContents = readFileSync(targetPath, 'utf-8')
+      atomicWriteFileSync(backupPath, backupContents, { backup: false })
+    }
+
+    renameSync(temporaryPath, targetPath)
+    temporaryPath = null
+  } finally {
+    if (temporaryPath && existsSync(temporaryPath)) {
+      rmSync(temporaryPath, { force: true })
+    }
+  }
+}
+
+export function atomicWriteJsonSync(targetPath: string, value: unknown): void {
+  atomicWriteFileSync(targetPath, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+export function readJsonWithBackupSync(targetPath: string): unknown {
+  try {
+    return JSON.parse(readFileSync(targetPath, 'utf-8')) as unknown
+  } catch (primaryError) {
+    const backupPath = `${targetPath}.bak`
+    if (!existsSync(backupPath)) {
+      throw primaryError
+    }
+    return JSON.parse(readFileSync(backupPath, 'utf-8')) as unknown
+  }
+}
+
+export function removeFileIfExistsSync(targetPath: string): void {
+  rmSync(targetPath, { force: true })
+}

--- a/src/main/persistence/presetStore.test.ts
+++ b/src/main/persistence/presetStore.test.ts
@@ -1,0 +1,51 @@
+import { existsSync, mkdirSync, rmSync } from 'fs'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockPaths = vi.hoisted(() => ({
+  userDataPath: `${process.env.TEMP ?? process.env.TMPDIR ?? '/tmp'}/nam-bot-preset-store-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => mockPaths.userDataPath,
+    getVersion: () => '0.6.2'
+  }
+}))
+
+import { createTrainingPreset } from '../../shared/training'
+import { deleteTrainingPreset, saveTrainingPreset } from './presetStore'
+
+beforeEach(() => {
+  rmSync(mockPaths.userDataPath, { recursive: true, force: true })
+  mkdirSync(mockPaths.userDataPath, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(mockPaths.userDataPath, { recursive: true, force: true })
+})
+
+describe('preset path validation', () => {
+  it('rejects traversal IDs for save and delete', () => {
+    const unsafePreset = createTrainingPreset({
+      id: '../settings',
+      name: 'Unsafe preset'
+    })
+
+    expect(() => saveTrainingPreset(unsafePreset)).toThrow('Preset ID')
+    expect(() => deleteTrainingPreset('..\\settings')).toThrow('Preset ID')
+    expect(existsSync(join(mockPaths.userDataPath, 'settings.json'))).toBe(false)
+  })
+
+  it('saves a valid preset inside the preset directory', () => {
+    const preset = createTrainingPreset({
+      id: 'safe-preset_1',
+      name: 'Safe preset'
+    })
+
+    const saved = saveTrainingPreset(preset)
+
+    expect(saved.id).toBe('safe-preset_1')
+    expect(existsSync(join(mockPaths.userDataPath, 'presets', 'safe-preset_1.json'))).toBe(true)
+  })
+})

--- a/src/main/persistence/presetStore.ts
+++ b/src/main/persistence/presetStore.ts
@@ -1,6 +1,6 @@
 import { app } from 'electron'
-import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'fs'
-import { join } from 'path'
+import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync } from 'fs'
+import { basename, join, resolve, sep } from 'path'
 import log from 'electron-log/main'
 import {
   DEFAULT_PRESET_ID,
@@ -11,6 +11,7 @@ import {
   normalizeTrainingPreset,
   slugifyPresetName
 } from '../types/jobs'
+import { atomicWriteJsonSync } from './atomicFile'
 
 const userPresetsPath = join(app.getPath('userData'), 'presets')
 
@@ -40,7 +41,16 @@ function ensurePresetDirectory(): void {
 }
 
 function getPresetFilePath(presetId: string): string {
-  return join(userPresetsPath, `${presetId}.json`)
+  if (!/^[a-z0-9][a-z0-9_-]{0,127}$/i.test(presetId)) {
+    throw new Error('Preset ID must contain only letters, numbers, underscores, and hyphens.')
+  }
+
+  const targetPath = resolve(userPresetsPath, `${presetId}.json`)
+  const presetRoot = `${resolve(userPresetsPath)}${sep}`
+  if (!targetPath.startsWith(presetRoot) || basename(targetPath) !== `${presetId}.json`) {
+    throw new Error('Preset path must remain inside the preset directory.')
+  }
+  return targetPath
 }
 
 function listUserPresetsInternal(): TrainingPresetFile[] {
@@ -162,7 +172,7 @@ export function saveTrainingPreset(input: unknown): TrainingPresetFile {
     updatedAt: new Date().toISOString(),
     origin: buildStoredPresetOrigin(preset)
   })
-  writeFileSync(getPresetFilePath(normalized.id), JSON.stringify(normalized, null, 2), 'utf-8')
+  atomicWriteJsonSync(getPresetFilePath(normalized.id), normalized)
   return normalized
 }
 

--- a/src/main/persistence/settingsStore.test.ts
+++ b/src/main/persistence/settingsStore.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => 'test-user-data'
+  }
+}))
+
+vi.mock('electron-log/main', () => ({
+  default: {
+    error: vi.fn(),
+    info: vi.fn()
+  }
+}))
+
+import { defaultSettings } from '../types'
+import { normalizeSettings } from './settingsStore'
+
+describe('normalizeSettings', () => {
+  it('migrates unsupported legacy settings to supported defaults and drops dead fields', () => {
+    const normalized = normalizeSettings({
+      backendMode: 'direct-python',
+      pythonExecutablePath: 'C:\\Python\\python.exe',
+      preferredLaunchMode: 'python-wrapper',
+      persistQueueOnExit: false,
+      logRetentionDays: 7
+    })
+
+    expect(normalized.backendMode).toBe('conda-name')
+    expect(normalized.environmentName).toBe(defaultSettings.environmentName)
+    expect(normalized).not.toHaveProperty('pythonExecutablePath')
+    expect(normalized).not.toHaveProperty('preferredLaunchMode')
+    expect(normalized).not.toHaveProperty('persistQueueOnExit')
+    expect(normalized).not.toHaveProperty('logRetentionDays')
+  })
+
+  it('keeps valid supported settings and repairs invalid field types', () => {
+    const normalized = normalizeSettings({
+      backendMode: 'conda-prefix',
+      environmentPrefixPath: 'C:\\envs\\nam',
+      autoOpenResultsFolder: 'yes',
+      defaultAuthorName: 'Dave'
+    })
+
+    expect(normalized.backendMode).toBe('conda-prefix')
+    expect(normalized.environmentPrefixPath).toBe('C:\\envs\\nam')
+    expect(normalized.autoOpenResultsFolder).toBe(defaultSettings.autoOpenResultsFolder)
+    expect(normalized.defaultAuthorName).toBe('Dave')
+  })
+})

--- a/src/main/persistence/settingsStore.ts
+++ b/src/main/persistence/settingsStore.ts
@@ -2,29 +2,71 @@ import { app } from 'electron'
 import { join } from 'path'
 import { existsSync, mkdirSync } from 'fs'
 import log from 'electron-log/main'
-import { AppSettings, defaultSettings } from '../types'
+import { AppSettings, BackendMode, defaultSettings } from '../types'
 import { atomicWriteJsonSync, readJsonWithBackupSync } from './atomicFile'
 
 const userDataPath = app.getPath('userData')
 const settingsPath = join(userDataPath, 'settings.json')
 
-function normalizeSettings(input: Partial<AppSettings> | null | undefined): AppSettings {
-  const mergedSettings: AppSettings = { ...defaultSettings, ...input }
+function normalizeNullableString(value: unknown, fallback: string | null): string | null {
+  return typeof value === 'string' ? value : fallback
+}
+
+function normalizeBackendMode(value: unknown): BackendMode {
+  return value === 'conda-prefix' ? 'conda-prefix' : 'conda-name'
+}
+
+function getSetting(input: unknown, key: keyof AppSettings): unknown {
+  return typeof input === 'object' && input !== null ? Reflect.get(input, key) : undefined
+}
+
+export function normalizeSettings(input: unknown): AppSettings {
+  const backendMode = normalizeBackendMode(getSetting(input, 'backendMode'))
+  const condaExecutablePath = normalizeNullableString(
+    getSetting(input, 'condaExecutablePath'),
+    defaultSettings.condaExecutablePath
+  ) || defaultSettings.condaExecutablePath
+  const environmentName = normalizeNullableString(
+    getSetting(input, 'environmentName'),
+    defaultSettings.environmentName
+  )
 
   return {
-    ...mergedSettings,
-    condaExecutablePath: mergedSettings.condaExecutablePath || defaultSettings.condaExecutablePath,
-    environmentName:
-      mergedSettings.backendMode === 'conda-name'
-        ? mergedSettings.environmentName || defaultSettings.environmentName
-        : mergedSettings.environmentName
+    condaExecutablePath,
+    backendMode,
+    environmentName: backendMode === 'conda-name'
+      ? environmentName || defaultSettings.environmentName
+      : environmentName,
+    environmentPrefixPath: normalizeNullableString(
+      getSetting(input, 'environmentPrefixPath'),
+      defaultSettings.environmentPrefixPath
+    ),
+    defaultOutputRoot: normalizeNullableString(
+      getSetting(input, 'defaultOutputRoot'),
+      defaultSettings.defaultOutputRoot
+    ),
+    defaultWorkspaceRoot: normalizeNullableString(
+      getSetting(input, 'defaultWorkspaceRoot'),
+      defaultSettings.defaultWorkspaceRoot
+    ),
+    autoOpenResultsFolder: typeof getSetting(input, 'autoOpenResultsFolder') === 'boolean'
+      ? getSetting(input, 'autoOpenResultsFolder') === true
+      : defaultSettings.autoOpenResultsFolder,
+    defaultAuthorName: normalizeNullableString(
+      getSetting(input, 'defaultAuthorName'),
+      defaultSettings.defaultAuthorName
+    ) ?? defaultSettings.defaultAuthorName,
+    defaultAuthorUrl: normalizeNullableString(
+      getSetting(input, 'defaultAuthorUrl'),
+      defaultSettings.defaultAuthorUrl
+    ) ?? defaultSettings.defaultAuthorUrl
   }
 }
 
 export function loadSettings(): AppSettings {
   try {
     if (existsSync(settingsPath)) {
-      const parsed = readJsonWithBackupSync(settingsPath) as Partial<AppSettings>
+      const parsed: unknown = readJsonWithBackupSync(settingsPath)
       log.info('Settings loaded from:', settingsPath)
       return normalizeSettings(parsed)
     }
@@ -35,14 +77,16 @@ export function loadSettings(): AppSettings {
   return normalizeSettings(defaultSettings)
 }
 
-export function saveSettings(settings: AppSettings): void {
+export function saveSettings(settings: AppSettings): AppSettings {
   try {
+    const normalizedSettings = normalizeSettings(settings)
     const dir = userDataPath
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true })
     }
-    atomicWriteJsonSync(settingsPath, settings)
+    atomicWriteJsonSync(settingsPath, normalizedSettings)
     log.info('Settings saved to:', settingsPath)
+    return normalizedSettings
   } catch (error) {
     log.error('Failed to save settings:', error)
     throw error

--- a/src/main/persistence/settingsStore.ts
+++ b/src/main/persistence/settingsStore.ts
@@ -1,8 +1,9 @@
 import { app } from 'electron'
 import { join } from 'path'
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { existsSync, mkdirSync } from 'fs'
 import log from 'electron-log/main'
 import { AppSettings, defaultSettings } from '../types'
+import { atomicWriteJsonSync, readJsonWithBackupSync } from './atomicFile'
 
 const userDataPath = app.getPath('userData')
 const settingsPath = join(userDataPath, 'settings.json')
@@ -23,8 +24,7 @@ function normalizeSettings(input: Partial<AppSettings> | null | undefined): AppS
 export function loadSettings(): AppSettings {
   try {
     if (existsSync(settingsPath)) {
-      const data = readFileSync(settingsPath, 'utf-8')
-      const parsed = JSON.parse(data) as Partial<AppSettings>
+      const parsed = readJsonWithBackupSync(settingsPath) as Partial<AppSettings>
       log.info('Settings loaded from:', settingsPath)
       return normalizeSettings(parsed)
     }
@@ -41,7 +41,7 @@ export function saveSettings(settings: AppSettings): void {
     if (!existsSync(dir)) {
       mkdirSync(dir, { recursive: true })
     }
-    writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8')
+    atomicWriteJsonSync(settingsPath, settings)
     log.info('Settings saved to:', settingsPath)
   } catch (error) {
     log.error('Failed to save settings:', error)

--- a/src/main/persistence/updateStore.ts
+++ b/src/main/persistence/updateStore.ts
@@ -1,8 +1,9 @@
 import { app } from 'electron'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync } from 'fs'
 import { join } from 'path'
 import log from 'electron-log/main'
 import { createDefaultUpdateStatus, type UpdateState, type UpdateStatus } from '../../shared/update'
+import { atomicWriteJsonSync, readJsonWithBackupSync } from './atomicFile'
 
 interface StoredUpdateStatus {
   currentVersion?: string
@@ -37,8 +38,7 @@ export function loadUpdateStatus(): UpdateStatus {
       return createDefaultUpdateStatus(app.getVersion())
     }
 
-    const data = readFileSync(updateStatusPath, 'utf-8')
-    const parsed = JSON.parse(data) as StoredUpdateStatus
+    const parsed = readJsonWithBackupSync(updateStatusPath) as StoredUpdateStatus
     return normalizeStoredStatus(parsed)
   } catch (error) {
     log.error('Failed to load update status:', error)
@@ -52,7 +52,7 @@ export function saveUpdateStatus(status: UpdateStatus): void {
       mkdirSync(userDataPath, { recursive: true })
     }
 
-    writeFileSync(updateStatusPath, JSON.stringify(status, null, 2), 'utf-8')
+    atomicWriteJsonSync(updateStatusPath, status)
   } catch (error) {
     log.error('Failed to save update status:', error)
   }

--- a/src/main/types/index.ts
+++ b/src/main/types/index.ts
@@ -1,17 +1,13 @@
-export type BackendMode = 'conda-name' | 'conda-prefix' | 'direct-python'
+export type BackendMode = 'conda-name' | 'conda-prefix'
 
 export interface AppSettings {
   condaExecutablePath: string | null
   backendMode: BackendMode
   environmentName: string | null
   environmentPrefixPath: string | null
-  pythonExecutablePath: string | null
   defaultOutputRoot: string | null
   defaultWorkspaceRoot: string | null
-  preferredLaunchMode: 'nam-full' | 'python-wrapper'
   autoOpenResultsFolder: boolean
-  persistQueueOnExit: boolean
-  logRetentionDays: number
   defaultAuthorName: string
   defaultAuthorUrl: string
 }
@@ -21,13 +17,9 @@ export const defaultSettings: AppSettings = {
   backendMode: 'conda-name',
   environmentName: 'nam',
   environmentPrefixPath: null,
-  pythonExecutablePath: null,
   defaultOutputRoot: null,
   defaultWorkspaceRoot: null,
-  preferredLaunchMode: 'nam-full',
   autoOpenResultsFolder: false,
-  persistQueueOnExit: true,
-  logRetentionDays: 30,
   defaultAuthorName: '',
   defaultAuthorUrl: ''
 }
@@ -122,7 +114,6 @@ export type TrainingLaunchDiagnosticsIssue =
   | 'conda_not_configured'
   | 'conda_unreachable'
   | 'environment_not_configured'
-  | 'direct_python_unsupported'
   | 'lightning_security_check_failed'
   | 'lightning_vulnerable'
   | 'workspace_unwritable'

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,6 +19,7 @@ export interface NamBotApi {
   }
   jobs: {
     createDraft: (input?: unknown) => Promise<unknown>
+    createDraftBatch: (input: unknown) => Promise<unknown[]>
     saveDraft: (job: unknown) => Promise<unknown>
     deleteDraft: (jobId: string) => Promise<void>
     listDrafts: () => Promise<unknown[]>
@@ -85,6 +86,7 @@ const api: NamBotApi = {
   },
   jobs: {
     createDraft: (input) => ipcRenderer.invoke('jobs:createDraft', input),
+    createDraftBatch: (input) => ipcRenderer.invoke('jobs:createDraftBatch', input),
     saveDraft: (job) => ipcRenderer.invoke('jobs:saveDraft', job),
     deleteDraft: (jobId) => ipcRenderer.invoke('jobs:deleteDraft', jobId),
     listDrafts: () => ipcRenderer.invoke('jobs:listDrafts'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
 
 import type { AppCommand } from '../shared/appShell'
+import type { LogChunk } from '../shared/logs'
 import type { UpdateStatus } from '../shared/update'
 
 export interface NamBotApi {
@@ -15,7 +16,6 @@ export interface NamBotApi {
     getNamVersionInfo: () => Promise<unknown>
     chooseCondaPath: () => Promise<string | null>
     chooseDirectory: () => Promise<string | null>
-    choosePythonPath: () => Promise<string | null>
   }
   jobs: {
     createDraft: (input?: unknown) => Promise<unknown>
@@ -54,6 +54,7 @@ export interface NamBotApi {
   }
   logs: {
     getTerminal: (jobId: string) => Promise<string>
+    getTerminalChunk: (jobId: string, offset: number | null) => Promise<LogChunk>
     getDiagnostics: () => Promise<string>
   }
   updates: {
@@ -81,8 +82,7 @@ const api: NamBotApi = {
     getTrainingLaunchDiagnostics: () => ipcRenderer.invoke('settings:getTrainingLaunchDiagnostics'),
     getNamVersionInfo: () => ipcRenderer.invoke('settings:getNamVersionInfo'),
     chooseCondaPath: () => ipcRenderer.invoke('settings:chooseCondaPath'),
-    chooseDirectory: () => ipcRenderer.invoke('settings:chooseDirectory'),
-    choosePythonPath: () => ipcRenderer.invoke('settings:choosePythonPath')
+    chooseDirectory: () => ipcRenderer.invoke('settings:chooseDirectory')
   },
   jobs: {
     createDraft: (input) => ipcRenderer.invoke('jobs:createDraft', input),
@@ -121,6 +121,7 @@ const api: NamBotApi = {
   },
   logs: {
     getTerminal: (jobId) => ipcRenderer.invoke('logs:getTerminal', jobId),
+    getTerminalChunk: (jobId, offset) => ipcRenderer.invoke('logs:getTerminalChunk', jobId, offset),
     getDiagnostics: () => ipcRenderer.invoke('logs:getDiagnostics')
   },
   updates: {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import {
   type JobEditorSession,
   type PresetEditorSession,
   TrainingLaunchDiagnosticsSummary,
+  shouldAutoLoadResource,
   useAppStore
 } from './state/store'
 import type { UpdateStatus } from '../shared/update'
@@ -246,9 +247,14 @@ function Dashboard() {
     trainingLaunchDiagnostics,
     namVersionInfo,
     isLoading,
+    isBackendValidationLoading,
     isAcceleratorDiagnosticsLoading,
     isTrainingLaunchDiagnosticsLoading,
     isNamVersionInfoLoading,
+    validationError,
+    acceleratorDiagnosticsError,
+    trainingLaunchDiagnosticsError,
+    namVersionInfoError,
     validateBackend,
     loadAcceleratorDiagnostics, 
     loadTrainingLaunchDiagnostics,
@@ -290,16 +296,16 @@ function Dashboard() {
   }, [trainingJobs.length])
 
   useEffect(() => {
-    if (!validation && !isLoading) {
+    if (shouldAutoLoadResource(validation, isBackendValidationLoading, validationError)) {
       void validateBackend()
     }
-    if (!acceleratorDiagnostics && !isAcceleratorDiagnosticsLoading) {
+    if (shouldAutoLoadResource(acceleratorDiagnostics, isAcceleratorDiagnosticsLoading, acceleratorDiagnosticsError)) {
       void loadAcceleratorDiagnostics()
     }
-    if (!trainingLaunchDiagnostics && !isTrainingLaunchDiagnosticsLoading) {
+    if (shouldAutoLoadResource(trainingLaunchDiagnostics, isTrainingLaunchDiagnosticsLoading, trainingLaunchDiagnosticsError)) {
       void loadTrainingLaunchDiagnostics()
     }
-    if (!namVersionInfo && !isNamVersionInfoLoading) {
+    if (shouldAutoLoadResource(namVersionInfo, isNamVersionInfoLoading, namVersionInfoError)) {
       void loadNamVersionInfo()
     }
     if (presets.length === 0) {
@@ -307,7 +313,9 @@ function Dashboard() {
     }
   }, [
     acceleratorDiagnostics,
+    acceleratorDiagnosticsError,
     isAcceleratorDiagnosticsLoading,
+    isBackendValidationLoading,
     isLoading,
     isNamVersionInfoLoading,
     isTrainingLaunchDiagnosticsLoading,
@@ -316,9 +324,12 @@ function Dashboard() {
     loadPresets,
     loadTrainingLaunchDiagnostics,
     namVersionInfo,
+    namVersionInfoError,
     presets.length,
     trainingLaunchDiagnostics,
+    trainingLaunchDiagnosticsError,
     validation,
+    validationError,
     validateBackend
   ])
 
@@ -478,6 +489,7 @@ function AppShell() {
   const [pendingAction, setPendingAction] = useState<PendingAppAction | null>(null)
   const { isTraining } = useAppStore()
   const isLoading = useAppStore((state) => state.isLoading)
+  const isBackendValidationLoading = useAppStore((state) => state.isBackendValidationLoading)
   const isAcceleratorDiagnosticsLoading = useAppStore((state) => state.isAcceleratorDiagnosticsLoading)
   const isTrainingLaunchDiagnosticsLoading = useAppStore((state) => state.isTrainingLaunchDiagnosticsLoading)
   const isNamVersionInfoLoading = useAppStore((state) => state.isNamVersionInfoLoading)
@@ -499,6 +511,7 @@ function AppShell() {
   const subscribeToJobEvents = useAppStore((state) => state.subscribeToJobEvents)
   const hasUpdateAvailable = updateStatus.state === 'update-available'
   const isDiagnosticsChecking = isLoading
+    || isBackendValidationLoading
     || isAcceleratorDiagnosticsLoading
     || isTrainingLaunchDiagnosticsLoading
     || isNamVersionInfoLoading

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { HashRouter, NavLink, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 
 import type { AppCommand } from '../shared/appShell'
@@ -24,6 +24,7 @@ import RuntimeCard from './features/jobs/RuntimeCard'
 import { buildJobEditorSession, createNewJobDraft } from './features/jobs/jobEditorSession'
 import { buildNewPresetDraft, buildPresetEditorSession } from './features/presets/presetEditorSession'
 import ConfirmDialog from './components/ConfirmDialog'
+import { useTerminalLogs } from './hooks/useTerminalLogs'
 import log from 'electron-log/renderer'
 
 type PendingAppAction =
@@ -267,8 +268,7 @@ function Dashboard() {
   
   const [expandedJobIds, setExpandedJobIds] = useState<Set<string>>(new Set())
   const [visibleLogJobIds, setVisibleLogJobIds] = useState<Set<string>>(new Set())
-  const [logContents, setLogContents] = useState<Record<string, string>>({})
-  const [loadingLogs, setLoadingLogs] = useState<Set<string>>(new Set())
+  const { logContents, loadingLogIds, loadTerminalLog } = useTerminalLogs()
   const [nowMs, setNowMs] = useState<number>(() => Date.now())
 
   const diagnosticsCards = getDashboardDiagnosticsCards(
@@ -361,14 +361,8 @@ function Dashboard() {
       return
     }
 
-    setLoadingLogs(prev => {
-      const next = new Set(prev)
-      next.add(jobId)
-      return next
-    })
     try {
-      const logContent = await window.namBot.logs.getTerminal(jobId)
-      setLogContents(prev => ({ ...prev, [jobId]: logContent }))
+      await loadTerminalLog(jobId)
       setVisibleLogJobIds(prev => {
         const next = new Set(prev)
         next.add(jobId)
@@ -376,14 +370,28 @@ function Dashboard() {
       })
     } catch (err) {
       log.error('Failed to load log for dashboard:', err)
-    } finally {
-      setLoadingLogs(prev => {
-        const next = new Set(prev)
-        next.delete(jobId)
-        return next
-      })
     }
   }
+
+  const queueRef = useRef(queue)
+  queueRef.current = queue
+
+  useEffect(() => {
+    if (visibleLogJobIds.size === 0) {
+      return
+    }
+
+    const interval = window.setInterval(() => {
+      for (const runtime of queueRef.current) {
+        if (visibleLogJobIds.has(runtime.jobId)
+          && (runtime.status === 'preparing' || runtime.status === 'running' || runtime.status === 'stopping')) {
+          void loadTerminalLog(runtime.jobId)
+        }
+      }
+    }, 1500)
+
+    return () => window.clearInterval(interval)
+  }, [loadTerminalLog, visibleLogJobIds])
 
   return (
     <div className="layout-main">
@@ -441,7 +449,7 @@ function Dashboard() {
                  isExpanded={expandedJobIds.has(job.jobId)}
                  isLogsVisible={visibleLogJobIds.has(job.jobId)}
                  terminalLog={logContents[job.jobId] || ''}
-                 isLoadingLog={loadingLogs.has(job.jobId)}
+                 isLoadingLog={loadingLogIds.has(job.jobId)}
                  onToggleExpanded={toggleExpanded}
                   onToggleLogs={toggleLogs}
                   onCancel={async (id: string) => { await window.namBot.jobs.cancel(id) }}

--- a/src/renderer/components/ConfirmDialog.tsx
+++ b/src/renderer/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, type ReactElement } from 'react'
 
 interface ConfirmDialogProps {
   isOpen: boolean
@@ -30,7 +30,7 @@ export default function ConfirmDialog({
   onConfirm,
   onCancel,
   onAlternate
-}: ConfirmDialogProps): JSX.Element | null {
+}: ConfirmDialogProps): ReactElement | null {
   const cancelButtonRef = useRef<HTMLButtonElement | null>(null)
 
   useEffect(() => {

--- a/src/renderer/components/JsonCodeEditor.tsx
+++ b/src/renderer/components/JsonCodeEditor.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, type ClipboardEvent } from 'react'
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  type ClipboardEvent,
+  type ComponentProps,
+  type ReactElement
+} from 'react'
 import CodeEditor from '@uiw/react-textarea-code-editor'
 import rehypePrism from 'rehype-prism-plus'
 import '@uiw/react-textarea-code-editor/dist.css'
@@ -22,7 +29,9 @@ interface JsonCodeEditorProps {
   onPaste?: (event: ClipboardEvent<HTMLTextAreaElement>) => void
 }
 
-const JSON_EDITOR_REHYPE_PLUGINS = [[rehypePrism, { ignoreMissing: true, showLineNumbers: true }]]
+const JSON_EDITOR_REHYPE_PLUGINS: NonNullable<ComponentProps<typeof CodeEditor>['rehypePlugins']> = [
+  [rehypePrism, { ignoreMissing: true, showLineNumbers: true }]
+]
 
 export default function JsonCodeEditor({
   id,
@@ -35,7 +44,7 @@ export default function JsonCodeEditor({
   minHeight = 180,
   onFormat,
   onPaste
-}: JsonCodeEditorProps): JSX.Element {
+}: JsonCodeEditorProps): ReactElement {
   const editorRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {

--- a/src/renderer/features/diagnostics/Diagnostics.tsx
+++ b/src/renderer/features/diagnostics/Diagnostics.tsx
@@ -8,6 +8,7 @@ import {
   NamVersionInfo,
   TrainingLaunchCheckResult,
   TrainingLaunchDiagnosticsSummary,
+  shouldAutoLoadResource,
   useAppStore
 } from '../../state/store'
 import { MIN_A2_NAM_VERSION } from '../../state/types'
@@ -1460,9 +1461,14 @@ export default function Diagnostics() {
     trainingLaunchDiagnostics,
     namVersionInfo,
     isLoading,
+    isBackendValidationLoading,
     isAcceleratorDiagnosticsLoading,
     isTrainingLaunchDiagnosticsLoading,
     isNamVersionInfoLoading,
+    validationError,
+    acceleratorDiagnosticsError,
+    trainingLaunchDiagnosticsError,
+    namVersionInfoError,
     loadSettings,
     validateBackend,
     loadAcceleratorDiagnostics,
@@ -1470,7 +1476,13 @@ export default function Diagnostics() {
     loadNamVersionInfo
   } = useAppStore()
 
-  const isChecking = isLoading || isAcceleratorDiagnosticsLoading || isTrainingLaunchDiagnosticsLoading || isNamVersionInfoLoading
+  const isChecking = isLoading || isBackendValidationLoading || isAcceleratorDiagnosticsLoading || isTrainingLaunchDiagnosticsLoading || isNamVersionInfoLoading
+  const diagnosticErrors = [
+    validationError,
+    acceleratorDiagnosticsError,
+    trainingLaunchDiagnosticsError,
+    namVersionInfoError
+  ].filter((message): message is string => Boolean(message))
   const [showAiPrompt, setShowAiPrompt] = useState(false)
   const [showRawJson, setShowRawJson] = useState(false)
   const [showAdvancedDetails, setShowAdvancedDetails] = useState(false)
@@ -1490,21 +1502,23 @@ export default function Diagnostics() {
     if (!settings && !isLoading) {
       void loadSettings()
     }
-    if (!validation && !isLoading) {
+    if (shouldAutoLoadResource(validation, isBackendValidationLoading, validationError)) {
       void validateBackend()
     }
-    if (!acceleratorDiagnostics && !isAcceleratorDiagnosticsLoading) {
+    if (shouldAutoLoadResource(acceleratorDiagnostics, isAcceleratorDiagnosticsLoading, acceleratorDiagnosticsError)) {
       void loadAcceleratorDiagnostics()
     }
-    if (!trainingLaunchDiagnostics && !isTrainingLaunchDiagnosticsLoading) {
+    if (shouldAutoLoadResource(trainingLaunchDiagnostics, isTrainingLaunchDiagnosticsLoading, trainingLaunchDiagnosticsError)) {
       void loadTrainingLaunchDiagnostics()
     }
-    if (!namVersionInfo && !isNamVersionInfoLoading) {
+    if (shouldAutoLoadResource(namVersionInfo, isNamVersionInfoLoading, namVersionInfoError)) {
       void loadNamVersionInfo()
     }
   }, [
     acceleratorDiagnostics,
+    acceleratorDiagnosticsError,
     isAcceleratorDiagnosticsLoading,
+    isBackendValidationLoading,
     isLoading,
     isNamVersionInfoLoading,
     isTrainingLaunchDiagnosticsLoading,
@@ -1513,9 +1527,12 @@ export default function Diagnostics() {
     loadSettings,
     loadTrainingLaunchDiagnostics,
     namVersionInfo,
+    namVersionInfoError,
     settings,
     trainingLaunchDiagnostics,
+    trainingLaunchDiagnosticsError,
     validation,
+    validationError,
     validateBackend
   ])
 
@@ -1547,6 +1564,11 @@ export default function Diagnostics() {
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '10px' }}>
           {tiles.map((tile) => <SummaryTileCard key={tile.title} tile={tile} />)}
         </div>
+        {diagnosticErrors.length > 0 && (
+          <div style={{ marginTop: '12px', color: 'var(--neon-magenta)', fontSize: '13px' }}>
+            Diagnostics could not complete: {diagnosticErrors.join(' ')} Use Re-check All to try again.
+          </div>
+        )}
       </div>
 
       <ActionCenter actions={actions} allReady={isSetupReady(validation, acceleratorDiagnostics, trainingLaunchDiagnostics)} onOpenSettings={() => navigate('/settings')} />

--- a/src/renderer/features/diagnostics/Diagnostics.tsx
+++ b/src/renderer/features/diagnostics/Diagnostics.tsx
@@ -39,8 +39,6 @@ interface DiagnosticsExportPayload {
     condaExecutablePath: string | null
     environmentName: string | null
     environmentPrefixPath: string | null
-    pythonExecutablePath: string | null
-    preferredLaunchMode: AppSettings['preferredLaunchMode'] | null
   }
   validation: BackendValidationSummary | null
   acceleratorDiagnostics: AcceleratorDiagnosticsSummary | null
@@ -238,10 +236,6 @@ function getEnvironmentReference(settings: AppSettings | null): string {
       return settings.environmentPrefixPath
         ? `Conda prefix "${settings.environmentPrefixPath}"`
         : 'Conda prefix not configured'
-    case 'direct-python':
-      return settings.pythonExecutablePath
-        ? `Python executable "${settings.pythonExecutablePath}"`
-        : 'Python executable not configured'
     default:
       return 'Unknown backend target'
   }
@@ -261,8 +255,6 @@ function getRuntimePrefix(settings: AppSettings | null): string | null {
       return settings.environmentPrefixPath
         ? `${quoteShell(settings.condaExecutablePath ?? (window.namBot.platform === 'win32' ? 'conda.exe' : 'conda'))} run --prefix ${quoteShell(settings.environmentPrefixPath)}`
         : null
-    case 'direct-python':
-      return settings.pythonExecutablePath ? quoteShell(settings.pythonExecutablePath) : null
     default:
       return null
   }
@@ -273,9 +265,6 @@ function buildPythonInlineCommand(settings: AppSettings | null, snippet: string)
   if (!runtimePrefix) {
     return `python -c "${snippet}"`
   }
-  if (settings?.backendMode === 'direct-python') {
-    return `${runtimePrefix} -c "${snippet}"`
-  }
   return `${runtimePrefix} python -c "${snippet}"`
 }
 
@@ -283,9 +272,6 @@ function buildPipCommand(settings: AppSettings | null, pipArgs: string): string 
   const runtimePrefix = getRuntimePrefix(settings)
   if (!runtimePrefix) {
     return `pip ${pipArgs}`
-  }
-  if (settings?.backendMode === 'direct-python') {
-    return `${runtimePrefix} -m pip ${pipArgs}`
   }
   return `${runtimePrefix} pip ${pipArgs}`
 }
@@ -329,8 +315,6 @@ function getEnvironmentActivationCommand(settings: AppSettings | null): string |
       return settings.environmentName ? `conda activate ${settings.environmentName}` : null
     case 'conda-prefix':
       return settings.environmentPrefixPath ? `conda activate "${settings.environmentPrefixPath}"` : null
-    case 'direct-python':
-      return null
     default:
       return null
   }
@@ -610,9 +594,7 @@ function buildDiagnosticsExportPayload(
       backendMode: settings?.backendMode ?? null,
       condaExecutablePath: settings?.condaExecutablePath ?? null,
       environmentName: settings?.environmentName ?? null,
-      environmentPrefixPath: settings?.environmentPrefixPath ?? null,
-      pythonExecutablePath: settings?.pythonExecutablePath ?? null,
-      preferredLaunchMode: settings?.preferredLaunchMode ?? null
+      environmentPrefixPath: settings?.environmentPrefixPath ?? null
     },
     validation,
     acceleratorDiagnostics,
@@ -715,8 +697,6 @@ function buildAiTroubleshootingPrompt(
     `- Conda executable: ${settings?.condaExecutablePath ?? 'Not configured'}`,
     `- Environment name: ${settings?.environmentName ?? 'Not configured'}`,
     `- Environment prefix: ${settings?.environmentPrefixPath ?? 'Not configured'}`,
-    `- Direct Python path: ${settings?.pythonExecutablePath ?? 'Not configured'}`,
-    `- Preferred launch mode: ${settings?.preferredLaunchMode ?? 'Not configured'}`,
     '',
     'Backend validation',
     backendLines,

--- a/src/renderer/features/jobs/Jobs.tsx
+++ b/src/renderer/features/jobs/Jobs.tsx
@@ -657,8 +657,8 @@ export default function Jobs() {
       }
     }
 
-    for (const outputFile of batchEditorState.outputFiles) {
-      const draftInput = buildDraftFromTemplateForOutput({
+    const draftInputs = batchEditorState.outputFiles.map((outputFile) => (
+      buildDraftFromTemplateForOutput({
         template,
         outputAudioPath: outputFile.outputAudioPath,
         outputFileName: outputFile.outputFileName,
@@ -666,18 +666,18 @@ export default function Jobs() {
         batchSourceName,
         useSharedMetadataName: sharedMetadataName.length > 0
       })
-      await window.namBot.jobs.createDraft(draftInput)
-    }
+    ))
 
-    if (batchEditorState.source?.kind === 'draft') {
-      await window.namBot.jobs.saveDraft({
-        ...batchEditorState.source.template,
-        batchId,
-        batchSourceName
-      })
-    } else if (batchEditorState.source?.kind === 'runtime') {
-      await window.namBot.jobs.tagBatchSource(batchEditorState.source.runtimeId, batchId, batchSourceName)
-    }
+    await window.namBot.jobs.createDraftBatch({
+      batchId,
+      batchSourceName,
+      drafts: draftInputs,
+      source: batchEditorState.source?.kind === 'draft'
+        ? { kind: 'draft', id: batchEditorState.source.template.id }
+        : batchEditorState.source?.kind === 'runtime'
+          ? { kind: 'runtime', id: batchEditorState.source.runtimeId }
+          : null
+    })
 
     setBatchEditorState(null)
     await loadData()
@@ -1195,6 +1195,8 @@ function JobEditor({
   const [defaultAudioPath, setDefaultAudioPath] = useState<string | null>(null)
   const [savingDefault, setSavingDefault] = useState(false)
   const [isUnsavedConfirmOpen, setIsUnsavedConfirmOpen] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const saveInFlightRef = useRef(false)
   const settingsDefaultOutputRoot = settings?.defaultOutputRoot?.trim() || null
   const visiblePresets = useMemo(
     () => presets.filter((preset) => preset.visible || preset.id === editedJob.presetId),
@@ -1313,6 +1315,9 @@ function JobEditor({
   const canSave = (allowSaveWithoutChanges || isDirty) && isValid
 
   const performSave = async (): Promise<void> => {
+    if (saveInFlightRef.current) {
+      return
+    }
     if (!isValid) {
       onSessionChange({
         ...session,
@@ -1320,24 +1325,31 @@ function JobEditor({
       })
       return Promise.resolve()
     }
-    if (editedJob.presetId) {
-      window.localStorage.setItem(LAST_USED_PRESET_STORAGE_KEY, editedJob.presetId)
+    saveInFlightRef.current = true
+    setIsSaving(true)
+    try {
+      if (editedJob.presetId) {
+        window.localStorage.setItem(LAST_USED_PRESET_STORAGE_KEY, editedJob.presetId)
+      }
+      window.localStorage.setItem(
+        LAST_APPEND_PRESET_NAME_STORAGE_KEY,
+        editedJob.appendPresetToModelFileName ? 'true' : 'false'
+      )
+      window.localStorage.setItem(
+        LAST_APPEND_ESR_STORAGE_KEY,
+        editedJob.appendEsrToModelFileName ? 'true' : 'false'
+      )
+      window.localStorage.setItem(
+        LAST_COPY_FINAL_MODEL_TO_OUTPUT_AUDIO_FOLDER_STORAGE_KEY,
+        editedJob.copyFinalModelToOutputAudioFolder ? 'true' : 'false'
+      )
+      persistOutputRootPreference(outputRootMode, editedJob.outputRootDir)
+      persistReusableJobDefaults(editedJob, inputMode)
+      await Promise.resolve(onSave(editedJob))
+    } finally {
+      saveInFlightRef.current = false
+      setIsSaving(false)
     }
-    window.localStorage.setItem(
-      LAST_APPEND_PRESET_NAME_STORAGE_KEY,
-      editedJob.appendPresetToModelFileName ? 'true' : 'false'
-    )
-    window.localStorage.setItem(
-      LAST_APPEND_ESR_STORAGE_KEY,
-      editedJob.appendEsrToModelFileName ? 'true' : 'false'
-    )
-    window.localStorage.setItem(
-      LAST_COPY_FINAL_MODEL_TO_OUTPUT_AUDIO_FOLDER_STORAGE_KEY,
-      editedJob.copyFinalModelToOutputAudioFolder ? 'true' : 'false'
-    )
-    persistOutputRootPreference(outputRootMode, editedJob.outputRootDir)
-    persistReusableJobDefaults(editedJob, inputMode)
-    await Promise.resolve(onSave(editedJob))
   }
 
   const handleSubmit = async (e: React.FormEvent): Promise<void> => {
@@ -1425,11 +1437,11 @@ function JobEditor({
               type="submit"
               form={JOB_EDITOR_FORM_ID}
               className={`btn btn-sm ${canSave ? 'btn-green' : 'btn-secondary'}`}
-              disabled={!canSave}
+              disabled={!canSave || isSaving}
             >
-              {saveLabel}
+              {isSaving ? 'Saving...' : saveLabel}
             </button>
-            <button type="button" className="btn btn-sm btn-secondary" onClick={handleAttemptExit}>
+            <button type="button" className="btn btn-sm btn-secondary" onClick={handleAttemptExit} disabled={isSaving}>
               Cancel
             </button>
           </div>
@@ -2012,11 +2024,11 @@ function JobEditor({
             <button
               type="submit"
               className={`btn ${canSave ? 'btn-green' : 'btn-secondary'}`}
-              disabled={!canSave}
+              disabled={!canSave || isSaving}
             >
-              {saveLabel}
+              {isSaving ? 'Saving...' : saveLabel}
             </button>
-            <button type="button" className="btn btn-secondary" onClick={handleAttemptExit}>
+            <button type="button" className="btn btn-secondary" onClick={handleAttemptExit} disabled={isSaving}>
               Cancel
             </button>
             {showValidationErrors && !isValid && (

--- a/src/renderer/features/jobs/Jobs.tsx
+++ b/src/renderer/features/jobs/Jobs.tsx
@@ -24,6 +24,7 @@ import {
   type JobOutputRootMode
 } from '../../state/store'
 import ConfirmDialog from '../../components/ConfirmDialog'
+import { useTerminalLogs } from '../../hooks/useTerminalLogs'
 import {
   DEFAULT_PRESET_ID,
   JobSpec,
@@ -356,7 +357,6 @@ export default function Jobs() {
   const queue = useAppStore((state) => state.queue)
   const setQueue = useAppStore((state) => state.setQueue)
   const loadJobs = useAppStore((state) => state.loadJobs)
-  const subscribeToJobEvents = useAppStore((state) => state.subscribeToJobEvents)
 
   useEffect(() => {
     const active = queue.some(r => r.status === 'preparing' || r.status === 'running' || r.status === 'stopping')
@@ -366,8 +366,7 @@ export default function Jobs() {
   const [queueError, setQueueError] = useState<string | null>(null)
   const [expandedJobs, setExpandedJobs] = useState<Record<string, boolean>>({})
   const [openLogs, setOpenLogs] = useState<Record<string, boolean>>({})
-  const [logContents, setLogContents] = useState<Record<string, string>>({})
-  const [loadingLogJobId, setLoadingLogJobId] = useState<string | null>(null)
+  const { logContents, loadingLogIds, loadTerminalLog, clearTerminalLog } = useTerminalLogs()
   const [nowMs, setNowMs] = useState<number>(() => Date.now())
   const [pendingDeleteJob, setPendingDeleteJob] = useState<JobSpec | null>(null)
   const [skipDraftDeleteConfirm, setSkipDraftDeleteConfirm] = useState(false)
@@ -460,15 +459,12 @@ export default function Jobs() {
   useEffect(() => {
     void loadPresets()
     void loadData()
+  }, [loadPresets, loadJobs])
 
-    const unsub = subscribeToJobEvents()
-    return unsub
-  }, [loadPresets, loadJobs, subscribeToJobEvents])
-
+  const hasActiveRuntimeClock = queue.some(
+    (runtime) => runtime.status === 'preparing' || runtime.status === 'running' || runtime.status === 'stopping'
+  )
   useEffect(() => {
-    const hasActiveRuntimeClock = queue.some(
-      (runtime) => runtime.status === 'preparing' || runtime.status === 'running' || runtime.status === 'stopping'
-    )
     if (!hasActiveRuntimeClock) {
       return
     }
@@ -478,24 +474,7 @@ export default function Jobs() {
     }, 1000)
 
     return () => window.clearInterval(interval)
-  }, [queue])
-
-  const loadTerminalLog = async (jobId: string, backgroundRefresh: boolean = false) => {
-    if (!backgroundRefresh) {
-      setLoadingLogJobId(jobId)
-    }
-    try {
-      const content = await window.namBot.logs.getTerminal(jobId)
-      setLogContents((current) => ({
-        ...current,
-        [jobId]: String(content || '')
-      }))
-    } finally {
-      if (!backgroundRefresh) {
-        setLoadingLogJobId((current) => (current === jobId ? null : current))
-      }
-    }
-  }
+  }, [hasActiveRuntimeClock])
 
   const queueRef = useRef(queue)
   queueRef.current = queue
@@ -513,12 +492,12 @@ export default function Jobs() {
         .map((runtime: JobRuntimeState) => runtime.jobId)
 
       activeVisibleLogIds.forEach((jobId: string) => {
-        void loadTerminalLog(jobId, true)
+        void loadTerminalLog(jobId)
       })
     }, 1500)
 
     return () => window.clearInterval(interval)
-  }, [openLogs])
+  }, [loadTerminalLog, openLogs])
 
   const handleCreateJob = () => {
     setJobEditorSession(buildJobEditorSession('New Job', createNewJobDraft({ presets, settings }), settings))
@@ -853,11 +832,7 @@ export default function Jobs() {
       delete next[jobId]
       return next
     })
-    setLogContents((current) => {
-      const next = { ...current }
-      delete next[jobId]
-      return next
-    })
+    clearTerminalLog(jobId)
     await loadData()
   }
 
@@ -1085,7 +1060,7 @@ export default function Jobs() {
                       isExpanded={expandedJobs[runtime.jobId] === true}
                       isLogsVisible={openLogs[runtime.jobId] === true}
                       terminalLog={logContents[runtime.jobId] || ''}
-                      isLoadingLog={loadingLogJobId === runtime.jobId}
+                      isLoadingLog={loadingLogIds.has(runtime.jobId)}
                       onToggleExpanded={toggleExpanded}
                       onToggleLogs={(entry) => toggleLogs(entry.jobId)}
                       onCancel={handleCancel}
@@ -1121,7 +1096,7 @@ export default function Jobs() {
                       isExpanded={expandedJobs[runtime.jobId] === true}
                       isLogsVisible={openLogs[runtime.jobId] === true}
                       terminalLog={logContents[runtime.jobId] || ''}
-                      isLoadingLog={loadingLogJobId === runtime.jobId}
+                      isLoadingLog={loadingLogIds.has(runtime.jobId)}
                       onToggleExpanded={toggleExpanded}
                       onToggleLogs={(entry) => toggleLogs(entry.jobId)}
                       onCancel={handleCancel}

--- a/src/renderer/features/jobs/RuntimeCard.test.ts
+++ b/src/renderer/features/jobs/RuntimeCard.test.ts
@@ -16,7 +16,9 @@ function buildRuntime(overrides: Partial<JobRuntimeState> = {}): JobRuntimeState
     frozenJob: {
       ...defaultJobSpec,
       id: 'failed-runtime-card',
-      name: 'Failed Runtime Card'
+      name: 'Failed Runtime Card',
+      createdAt: '2026-07-03T12:00:00.000Z',
+      updatedAt: '2026-07-03T12:00:00.000Z'
     },
     userMessages: ['Training exited with code 1.'],
     ...overrides

--- a/src/renderer/features/settings/Settings.tsx
+++ b/src/renderer/features/settings/Settings.tsx
@@ -241,7 +241,6 @@ export default function Settings() {
           >
             <option value="conda-name">Conda Environment Name</option>
             <option value="conda-prefix">Conda Environment Prefix</option>
-            <option value="direct-python">Direct Python Path</option>
           </select>
         </div>
 
@@ -271,21 +270,6 @@ export default function Settings() {
                 setLocalSettings({ ...localSettings, environmentPrefixPath: e.target.value || null })
               }}
               placeholder="C:\Users\...\miniconda3\envs\nam"
-            />
-          </div>
-        )}
-
-        {localSettings.backendMode === 'direct-python' && (
-          <div className="form-group">
-            <label className="form-label">Python Executable Path</label>
-            <input
-              type="text"
-              className="form-input"
-              value={localSettings.pythonExecutablePath || ''}
-              onChange={(e) => {
-                setLocalSettings({ ...localSettings, pythonExecutablePath: e.target.value || null })
-              }}
-              placeholder={window.namBot.platform === 'win32' ? 'C:\\Users\\...\\python.exe' : '/usr/bin/python3'}
             />
           </div>
         )}
@@ -402,34 +386,6 @@ export default function Settings() {
           </label>
         </div>
 
-        <div className="form-group">
-          <label className="checkbox-container">
-            <input
-              type="checkbox"
-              checked={localSettings.persistQueueOnExit}
-              onChange={(e) => {
-                setLocalSettings({ ...localSettings, persistQueueOnExit: e.target.checked })
-              }}
-            />
-            <span className="checkmark"></span>
-            <span className="label-text">Persist queue on exit</span>
-          </label>
-        </div>
-
-        <div className="form-group">
-          <label className="form-label">Log Retention (days)</label>
-          <input
-            type="number"
-            className="form-input"
-            value={localSettings.logRetentionDays}
-            onChange={(e) => {
-              setLocalSettings({ ...localSettings, logRetentionDays: parseInt(e.target.value) || 30 })
-            }}
-            min={1}
-            max={365}
-            style={{ width: '100px' }}
-          />
-        </div>
       </div>
     </div>
   )

--- a/src/renderer/features/settings/Settings.tsx
+++ b/src/renderer/features/settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useAppStore, AppSettings, BackendValidationSummary } from '../../state/store'
 import ConfirmDialog from '../../components/ConfirmDialog'
 
@@ -42,7 +42,10 @@ export default function Settings() {
     settings,
     validation,
     condaDiscovery,
-    isLoading,
+    isSettingsSaving,
+    isBackendValidationLoading,
+    settingsSaveError,
+    validationError,
     loadSettings,
     saveSettings,
     validateBackend,
@@ -50,6 +53,9 @@ export default function Settings() {
   } = useAppStore()
   const [localSettings, setLocalSettings] = useState<AppSettings | null>(null)
   const [useCustomCondaPath, setUseCustomCondaPath] = useState(false)
+  const saveTimerRef = useRef<number | null>(null)
+  const latestSettingsRef = useRef<AppSettings | null>(null)
+  const persistedSettingsRef = useRef<AppSettings | null>(null)
 
   useEffect(() => {
     void loadSettings()
@@ -65,23 +71,58 @@ export default function Settings() {
     }
   }, [settings, localSettings])
 
-  // Debounced auto-save
   useEffect(() => {
-    if (!localSettings || !settings) return
-
-    // Skip if identical to current store settings
-    if (JSON.stringify(localSettings) === JSON.stringify(settings)) {
+    latestSettingsRef.current = localSettings
+    persistedSettingsRef.current = settings
+    if (saveTimerRef.current !== null) {
+      window.clearTimeout(saveTimerRef.current)
+      saveTimerRef.current = null
+    }
+    if (!localSettings || !settings || JSON.stringify(localSettings) === JSON.stringify(settings)) {
       return
     }
 
-    const timer = setTimeout(() => {
-      void saveSettings(localSettings)
-    }, 1000)
-
-    return () => clearTimeout(timer)
+    const settingsSnapshot = localSettings
+    saveTimerRef.current = window.setTimeout(() => {
+      saveTimerRef.current = null
+      void saveSettings(settingsSnapshot).catch(() => undefined)
+    }, 500)
   }, [localSettings, settings, saveSettings])
 
-  const handleValidate = async () => {
+  useEffect(() => () => {
+    if (saveTimerRef.current !== null) {
+      window.clearTimeout(saveTimerRef.current)
+    }
+    const latestSettings = latestSettingsRef.current
+    const persistedSettings = persistedSettingsRef.current
+    if (latestSettings && JSON.stringify(latestSettings) !== JSON.stringify(persistedSettings)) {
+      void saveSettings(latestSettings).catch(() => undefined)
+    }
+  }, [saveSettings])
+
+  const handleSave = async (): Promise<boolean> => {
+    if (!localSettings) {
+      return false
+    }
+    if (saveTimerRef.current !== null) {
+      window.clearTimeout(saveTimerRef.current)
+      saveTimerRef.current = null
+    }
+    try {
+      await saveSettings(localSettings)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  const handleValidate = async (): Promise<void> => {
+    if (localSettings && JSON.stringify(localSettings) !== JSON.stringify(settings)) {
+      const saved = await handleSave()
+      if (!saved) {
+        return
+      }
+    }
     await validateBackend()
   }
 
@@ -113,17 +154,27 @@ export default function Settings() {
   const displayedCondaPath: string = usingPathConda
     ? (condaDiscovery?.resolvedPath || localSettings.condaExecutablePath || (window.namBot.platform === 'win32' ? 'conda.exe' : 'conda'))
     : (localSettings.condaExecutablePath || '')
+  const hasUnsavedChanges = JSON.stringify(localSettings) !== JSON.stringify(settings)
+  const isBackendBusy = isSettingsSaving || isBackendValidationLoading
 
   return (
     <div className="layout-main">
       <div className="panel" style={{ marginBottom: '16px' }}>
         <div className="panel-header">
           <h3>Settings</h3>
-          {isLoading && (
-            <span style={{ fontSize: '13px', color: 'var(--text-steel)', fontFamily: 'var(--font-arcade)' }}>
-              Saving...
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <span style={{ fontSize: '13px', color: settingsSaveError ? 'var(--neon-magenta)' : 'var(--text-steel)', fontFamily: 'var(--font-arcade)' }}>
+              {settingsSaveError ? `Save failed: ${settingsSaveError}` : isSettingsSaving ? 'Saving...' : hasUnsavedChanges ? 'Unsaved changes' : 'Saved'}
             </span>
-          )}
+            <button
+              type="button"
+              className={`btn btn-sm ${hasUnsavedChanges ? 'btn-green' : 'btn-secondary'}`}
+              disabled={!hasUnsavedChanges || isBackendBusy}
+              onClick={() => void handleSave()}
+            >
+              Save Settings
+            </button>
+          </div>
         </div>
       </div>
 
@@ -241,12 +292,17 @@ export default function Settings() {
 
         <div style={{ marginTop: '16px' }}>
           <button 
-            className={`btn btn-green ${isLoading ? 'processing-text' : ''}`} 
+            className={`btn btn-green ${isBackendBusy ? 'processing-text' : ''}`}
             onClick={handleValidate} 
-            disabled={isLoading}
+            disabled={isBackendBusy}
           >
-            {isLoading ? 'Validating' : (validation?.overallOk ? '✓ Backend Ready' : 'Validate Backend')}
+            {isBackendValidationLoading ? 'Validating' : (!hasUnsavedChanges && validation?.overallOk ? '✓ Backend Ready' : 'Validate Backend')}
           </button>
+          {validationError && (
+            <p style={{ marginTop: '8px', color: 'var(--neon-magenta)', fontSize: '13px' }}>
+              Validation failed: {validationError}
+            </p>
+          )}
         </div>
       </div>
 

--- a/src/renderer/hooks/useTerminalLogs.ts
+++ b/src/renderer/hooks/useTerminalLogs.ts
@@ -1,0 +1,73 @@
+import { useCallback, useRef, useState } from 'react'
+
+const MAX_RENDERED_LOG_CHARACTERS = 512 * 1024
+const CLIENT_TRUNCATION_NOTICE = '[Earlier displayed log output omitted]\n'
+
+function limitRenderedLog(content: string): string {
+  if (content.length <= MAX_RENDERED_LOG_CHARACTERS) {
+    return content
+  }
+  return `${CLIENT_TRUNCATION_NOTICE}${content.slice(-MAX_RENDERED_LOG_CHARACTERS)}`
+}
+
+interface TerminalLogsState {
+  logContents: Record<string, string>
+  loadingLogIds: Set<string>
+  loadTerminalLog: (jobId: string) => Promise<void>
+  clearTerminalLog: (jobId: string) => void
+}
+
+export function useTerminalLogs(): TerminalLogsState {
+  const [logContents, setLogContents] = useState<Record<string, string>>({})
+  const [loadingLogIds, setLoadingLogIds] = useState<Set<string>>(() => new Set())
+  const offsetsRef = useRef<Record<string, number>>({})
+  const inFlightRef = useRef<Set<string>>(new Set())
+
+  const loadTerminalLog = useCallback(async (jobId: string): Promise<void> => {
+    if (inFlightRef.current.has(jobId)) {
+      return
+    }
+
+    inFlightRef.current.add(jobId)
+    setLoadingLogIds((current) => new Set(current).add(jobId))
+    try {
+      const offset = offsetsRef.current[jobId] ?? null
+      const chunk = await window.namBot.logs.getTerminalChunk(jobId, offset)
+      offsetsRef.current[jobId] = chunk.nextOffset
+      if (chunk.content.length === 0 && !chunk.reset) {
+        return
+      }
+      setLogContents((current) => ({
+        ...current,
+        [jobId]: limitRenderedLog(chunk.reset
+          ? chunk.content
+          : `${current[jobId] ?? ''}${chunk.content}`)
+      }))
+    } catch (error) {
+      console.error(`Failed to load terminal log for ${jobId}:`, error)
+    } finally {
+      inFlightRef.current.delete(jobId)
+      setLoadingLogIds((current) => {
+        const next = new Set(current)
+        next.delete(jobId)
+        return next
+      })
+    }
+  }, [])
+
+  const clearTerminalLog = useCallback((jobId: string): void => {
+    delete offsetsRef.current[jobId]
+    setLogContents((current) => {
+      const next = { ...current }
+      delete next[jobId]
+      return next
+    })
+  }, [])
+
+  return {
+    logContents,
+    loadingLogIds,
+    loadTerminalLog,
+    clearTerminalLog
+  }
+}

--- a/src/renderer/state/store.test.ts
+++ b/src/renderer/state/store.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldAutoLoadResource } from './store'
+
+describe('diagnostic auto-loading', () => {
+  it('loads an idle resource once', () => {
+    expect(shouldAutoLoadResource(null, false, null)).toBe(true)
+  })
+
+  it('does not automatically retry a failed resource', () => {
+    expect(shouldAutoLoadResource(null, false, 'probe failed')).toBe(false)
+  })
+
+  it('does not overlap an in-flight request', () => {
+    expect(shouldAutoLoadResource(null, true, null)).toBe(false)
+  })
+})

--- a/src/renderer/state/store.ts
+++ b/src/renderer/state/store.ts
@@ -55,6 +55,18 @@ function sortPresets(presets: TrainingPresetFile[]): TrainingPresetFile[] {
   })
 }
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function shouldAutoLoadResource(
+  value: unknown,
+  loading: boolean,
+  error: string | null
+): boolean {
+  return value == null && !loading && error == null
+}
+
 export type BackendMode = 'conda-name' | 'conda-prefix' | 'direct-python'
 
 export interface AppSettings {
@@ -263,9 +275,18 @@ interface AppState {
   presetEditorSession: PresetEditorSession | null
   jobEditorSession: JobEditorSession | null
   isLoading: boolean;
+  isSettingsSaving: boolean;
+  isBackendValidationLoading: boolean;
   isAcceleratorDiagnosticsLoading: boolean;
   isTrainingLaunchDiagnosticsLoading: boolean;
   isNamVersionInfoLoading: boolean;
+  settingsLoadError: string | null;
+  settingsSaveError: string | null;
+  validationError: string | null;
+  acceleratorDiagnosticsError: string | null;
+  trainingLaunchDiagnosticsError: string | null;
+  namVersionInfoError: string | null;
+  settingsRevision: number;
   isTraining: boolean;
   drafts: JobSpec[];
   queue: JobRuntimeState[];
@@ -314,19 +335,28 @@ export const useAppStore = create<AppState>((set, get) => ({
   presetEditorSession: null,
   jobEditorSession: null,
   isLoading: false,
+  isSettingsSaving: false,
+  isBackendValidationLoading: false,
   isAcceleratorDiagnosticsLoading: false,
   isTrainingLaunchDiagnosticsLoading: false,
   isNamVersionInfoLoading: false,
+  settingsLoadError: null,
+  settingsSaveError: null,
+  validationError: null,
+  acceleratorDiagnosticsError: null,
+  trainingLaunchDiagnosticsError: null,
+  namVersionInfoError: null,
+  settingsRevision: 0,
   isTraining: false,
   drafts: [],
   queue: [],
   
   setSettings: (settings) => set({ settings }),
-  setValidation: (validation) => set({ validation }),
-  setAcceleratorDiagnostics: (acceleratorDiagnostics) => set({ acceleratorDiagnostics }),
-  setTrainingLaunchDiagnostics: (trainingLaunchDiagnostics) => set({ trainingLaunchDiagnostics }),
+  setValidation: (validation) => set({ validation, validationError: null }),
+  setAcceleratorDiagnostics: (acceleratorDiagnostics) => set({ acceleratorDiagnostics, acceleratorDiagnosticsError: null }),
+  setTrainingLaunchDiagnostics: (trainingLaunchDiagnostics) => set({ trainingLaunchDiagnostics, trainingLaunchDiagnosticsError: null }),
   setCondaDiscovery: (condaDiscovery) => set({ condaDiscovery }),
-  setNamVersionInfo: (namVersionInfo) => set({ namVersionInfo }),
+  setNamVersionInfo: (namVersionInfo) => set({ namVersionInfo, namVersionInfoError: null }),
   setUpdateStatus: (updateStatus) => set({ updateStatus }),
   setPresets: (presets) => set({ presets: sortPresets(presets) }),
   setPresetEditorSession: (presetEditorSession) => set({ presetEditorSession }),
@@ -345,41 +375,61 @@ export const useAppStore = create<AppState>((set, get) => ({
   })),
   
   loadSettings: async () => {
-    set({ isLoading: true })
+    set({ isLoading: true, settingsLoadError: null })
     try {
       const settings = await window.namBot.settings.get() as AppSettings
       set({ settings })
     } catch (error) {
       console.error('Failed to load settings:', error)
+      set({ settingsLoadError: getErrorMessage(error) })
     } finally {
       set({ isLoading: false })
     }
   },
   
   saveSettings: async (settings) => {
-    set({ isLoading: true })
+    set({ isSettingsSaving: true, settingsSaveError: null })
     try {
       await window.namBot.settings.save(settings)
-      set({ settings })
+      set((state) => ({
+        settings,
+        settingsRevision: state.settingsRevision + 1,
+        validation: null,
+        acceleratorDiagnostics: null,
+        trainingLaunchDiagnostics: null,
+        namVersionInfo: null,
+        validationError: null,
+        acceleratorDiagnosticsError: null,
+        trainingLaunchDiagnosticsError: null,
+        namVersionInfoError: null
+      }))
     } catch (error) {
       console.error('Failed to save settings:', error)
+      set({ settingsSaveError: getErrorMessage(error) })
+      throw error
     } finally {
-      set({ isLoading: false })
+      set({ isSettingsSaving: false })
     }
   },
   
   validateBackend: async () => {
-    if (get().isLoading) {
+    if (get().isBackendValidationLoading) {
       return
     }
-    set({ isLoading: true })
+    const revision = get().settingsRevision
+    set({ isBackendValidationLoading: true, validationError: null })
     try {
       const validation = await window.namBot.settings.validate() as BackendValidationSummary
-      set({ validation })
+      if (get().settingsRevision === revision) {
+        set({ validation })
+      }
     } catch (error) {
       console.error('Failed to validate backend:', error)
+      if (get().settingsRevision === revision) {
+        set({ validationError: getErrorMessage(error) })
+      }
     } finally {
-      set({ isLoading: false })
+      set({ isBackendValidationLoading: false })
     }
   },
 
@@ -387,13 +437,19 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (get().isAcceleratorDiagnosticsLoading) {
       return
     }
-    set({ isAcceleratorDiagnosticsLoading: true })
+    const revision = get().settingsRevision
+    set({ isAcceleratorDiagnosticsLoading: true, acceleratorDiagnosticsError: null })
     try {
       const acceleratorDiagnostics =
         await window.namBot.settings.getAcceleratorDiagnostics() as AcceleratorDiagnosticsSummary
-      set({ acceleratorDiagnostics })
+      if (get().settingsRevision === revision) {
+        set({ acceleratorDiagnostics })
+      }
     } catch (error) {
       console.error('Failed to load accelerator diagnostics:', error)
+      if (get().settingsRevision === revision) {
+        set({ acceleratorDiagnosticsError: getErrorMessage(error) })
+      }
     } finally {
       set({ isAcceleratorDiagnosticsLoading: false })
     }
@@ -403,13 +459,19 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (get().isTrainingLaunchDiagnosticsLoading) {
       return
     }
-    set({ isTrainingLaunchDiagnosticsLoading: true })
+    const revision = get().settingsRevision
+    set({ isTrainingLaunchDiagnosticsLoading: true, trainingLaunchDiagnosticsError: null })
     try {
       const trainingLaunchDiagnostics =
         await window.namBot.settings.getTrainingLaunchDiagnostics() as TrainingLaunchDiagnosticsSummary
-      set({ trainingLaunchDiagnostics })
+      if (get().settingsRevision === revision) {
+        set({ trainingLaunchDiagnostics })
+      }
     } catch (error) {
       console.error('Failed to load training launch diagnostics:', error)
+      if (get().settingsRevision === revision) {
+        set({ trainingLaunchDiagnosticsError: getErrorMessage(error) })
+      }
     } finally {
       set({ isTrainingLaunchDiagnosticsLoading: false })
     }
@@ -419,13 +481,18 @@ export const useAppStore = create<AppState>((set, get) => ({
     if (get().isNamVersionInfoLoading) {
       return
     }
-    set({ isNamVersionInfoLoading: true })
+    const revision = get().settingsRevision
+    set({ isNamVersionInfoLoading: true, namVersionInfoError: null })
     try {
       const namVersionInfo = await window.namBot.settings.getNamVersionInfo() as NamVersionInfo
-      set({ namVersionInfo })
+      if (get().settingsRevision === revision) {
+        set({ namVersionInfo })
+      }
     } catch (error) {
       console.error('Failed to load NAM version info:', error)
-      set({ namVersionInfo: null })
+      if (get().settingsRevision === revision) {
+        set({ namVersionInfo: null, namVersionInfoError: getErrorMessage(error) })
+      }
     } finally {
       set({ isNamVersionInfoLoading: false })
     }

--- a/src/renderer/state/store.ts
+++ b/src/renderer/state/store.ts
@@ -67,20 +67,16 @@ export function shouldAutoLoadResource(
   return value == null && !loading && error == null
 }
 
-export type BackendMode = 'conda-name' | 'conda-prefix' | 'direct-python'
+export type BackendMode = 'conda-name' | 'conda-prefix'
 
 export interface AppSettings {
   condaExecutablePath: string | null
   backendMode: BackendMode
   environmentName: string | null
   environmentPrefixPath: string | null
-  pythonExecutablePath: string | null
   defaultOutputRoot: string | null
   defaultWorkspaceRoot: string | null
-  preferredLaunchMode: 'nam-full' | 'python-wrapper'
   autoOpenResultsFolder: boolean
-  persistQueueOnExit: boolean
-  logRetentionDays: number
   defaultAuthorName: string
   defaultAuthorUrl: string
 }
@@ -175,7 +171,6 @@ export type TrainingLaunchDiagnosticsIssue =
   | 'conda_not_configured'
   | 'conda_unreachable'
   | 'environment_not_configured'
-  | 'direct_python_unsupported'
   | 'lightning_security_check_failed'
   | 'lightning_vulnerable'
   | 'workspace_unwritable'

--- a/src/shared/logs.ts
+++ b/src/shared/logs.ts
@@ -1,0 +1,6 @@
+export interface LogChunk {
+  content: string
+  nextOffset: number
+  reset: boolean
+  truncated: boolean
+}

--- a/src/shared/training.test.ts
+++ b/src/shared/training.test.ts
@@ -31,6 +31,7 @@ function buildTestJobSpec(): JobSpec {
     presetId: 'legacy-custom-preset',
     appendPresetToModelFileName: false,
     appendEsrToModelFileName: false,
+    copyFinalModelToOutputAudioFolder: false,
     inputAudioPath: 'C:\\input.wav',
     inputAudioIsDefault: false,
     outputAudioPath: 'C:\\output.wav',

--- a/src/shared/training.ts
+++ b/src/shared/training.ts
@@ -875,7 +875,11 @@ function computeLockedJobFields(expert: TrainingPresetExpertBlocks): Array<'epoc
   return lockedFields
 }
 
-export function createTrainingPreset(partial?: Partial<TrainingPresetFile>): TrainingPresetFile {
+type TrainingPresetInput = Omit<Partial<TrainingPresetFile>, 'values'> & {
+  values?: Partial<TrainingPresetValues>
+}
+
+export function createTrainingPreset(partial?: TrainingPresetInput): TrainingPresetFile {
   const now = new Date().toISOString()
   const values = {
     ...DEFAULT_TRAINING_PRESET_VALUES,
@@ -1066,8 +1070,7 @@ export function normalizeJobSpec(value: unknown): JobSpec {
 
   const legacyLearningSettings = isRecord(value.learningSettings) ? value.learningSettings : {}
   const legacyModelSettings = isRecord(value.modelSettings) ? value.modelSettings : {}
-  const hasTrainingOverrides = isRecord(value.trainingOverrides)
-  const trainingOverrides = hasTrainingOverrides ? value.trainingOverrides : {}
+  const trainingOverrides = isRecord(value.trainingOverrides) ? value.trainingOverrides : {}
   const legacyModelType = asString(legacyModelSettings.modelType, '')
   const hasLegacyLatencySamples = Object.prototype.hasOwnProperty.call(trainingOverrides, 'latencySamples')
   const latencyModeFallback: JobLatencyMode = Object.prototype.hasOwnProperty.call(trainingOverrides, 'latencyMode')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,5 @@
     "noEmit": true,
     "declaration": true
   },
-  "references": [
-    { "path": "./tsconfig.node.json" },
-    { "path": "./tsconfig.web.json" }
-  ]
+  "files": []
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
     "types": ["node"],
@@ -10,6 +9,11 @@
   "include": [
     "src/main/**/*.ts",
     "src/preload/**/*.ts",
+    "src/shared/**/*.ts",
     "electron.vite.config.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "moduleResolution": "bundler",
+    "types": ["node", "vite/client", "vitest/globals"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
+}

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "moduleResolution": "bundler",
@@ -12,5 +11,9 @@
     "src/renderer/**/*.ts",
     "src/renderer/**/*.tsx",
     "src/shared/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
## Summary
- Freeze queued preset recipes and attribution; improve queue/draft recovery, resume controls, shutdown confirmation, and process-event isolation.
- Improve settings and diagnostics consistency, batch editing, error reporting, finalization, and terminal-log refresh.
- Reconcile latest main while preserving snapshot export, Save & Stop, and ESR chart controls. Use frozen preset attribution for snapshots and keep finalization warnings visible after early finish.
- Prepare the approved 0.6.6 patch with synchronized package metadata, updated documentation, and consolidated release notes.

## Verification
- `npm run check` passed with `NAM_BOT_SMOKE_PYTHON` enabled: TypeScript checks, 142 Vitest tests, 8 release-metadata tests, and production builds.
- Real NAM 0.13.0 CPU smoke test passed: packed best-weight export preserves live weights, optimizer state, RNG, and normalization, then finishes early.
- Added regression coverage for exports after preset edits/deletion, Save & Stop finalization, and completion-warning visibility.
- After the version bump, validated release metadata against `v0.6.6`, reran all 8 release-metadata tests, and ran `npm run build` successfully.
- `git diff --check` passed; all merge conflicts are resolved.

## History and release notes
Earlier commits in this branch were already squash-merged through #20. Latest main is now merged into this branch; the net diff contains the follow-up reliability work and 0.6.6 preparation.

No release tag has been pushed. Publishing the stable release remains a separate step after merge and final smoke testing.